### PR TITLE
Rename vega-lite-tooltip to vega-tooltip. Fix #42.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 data
 node_modules
-/vl-tooltip.min.js
-/vl-tooltip.css
+/vg-tooltip.min.js
+/vg-tooltip.css
 settings.json

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ The development of Vega Tooltip is led by Zening Qu, with significant help from 
 http://vega.github.io/vega-tooltip/
 
 ## APIs
-For Vega-Lite: [`vl.tooltip(vgView, vlSpec[, options])`](https://github.com/vega/vega-lite-tooltip/wiki/APIs#vltooltip)
+For Vega-Lite: [`vl.tooltip(vgView, vlSpec[, options])`](https://github.com/vega/vega-tooltip/wiki/APIs#vltooltip)
 
-For Vega: [`vg.tooltip(vgView[, options])`](https://github.com/vega/vega-lite-tooltip/wiki/APIs#vltooltip)
+For Vega: [`vg.tooltip(vgView[, options])`](https://github.com/vega/vega-tooltip/wiki/APIs#vltooltip)
 
 ## Tutorials
 1. [Creating Your Tooltip](docs/creating_your_tooltip.md)

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ The development of Vega Tooltip is led by Zening Qu, with significant help from 
 http://vega.github.io/vega-tooltip/
 
 ## APIs
-For Vega-Lite: [`vl.tooltip(vgView, vlSpec[, options])`](https://github.com/vega/vega-tooltip/wiki/APIs#vltooltip)
+For Vega-Lite: [`vl.tooltip(vgView, vlSpec[, options])`](docs/APIs.md#vltooltip)
 
-For Vega: [`vg.tooltip(vgView[, options])`](https://github.com/vega/vega-tooltip/wiki/APIs#vltooltip)
+For Vega: [`vg.tooltip(vgView[, options])`](docs/APIs.md#vgtooltip)
 
 ## Tutorials
 1. [Creating Your Tooltip](docs/creating_your_tooltip.md)

--- a/docs/APIs.md
+++ b/docs/APIs.md
@@ -1,37 +1,27 @@
-# Customizing Your Tooltip
+# [vg.tooltip](#vgtooltip)
 
-__Previous Tutorial:__ [Creating Your Tooltip](creating_your_tooltip.md).
+`vg.tooltip(vgView[, options])`
 
-You can customize the content and look of your tooltip by passing in an optional `options` parameter to the tooltip API.
-
-For [Vega-Lite](https://vega.github.io/vega-lite/):
-
-```js
-var embedSpec = {
-  mode: "vega-lite",
-  spec: vlSpec
-};
-vg.embed("#vis-scatter", embedSpec, function(error, result) {
-  // result.view is the Vega View, vlSpec is the original Vega-Lite specification
-  vl.tooltip(result.view, vlSpec, options); // pass in options
-});
-```
-
-For [Vega](http://vega.github.io/vega/):
-
-```js
-vg.parse.spec(vgSpec, function(error, chart) {
-  // view is the Vega View
-  var view = chart({el:"#vis-scatter"}).update();
-  vg.tooltip(view, options); // pass in options
-});
-```
+| Parameter       | Type           | Description     |
+| :-------------- |:--------------:| :-------------- |
+| `vgView`        | [Vega View](https://github.com/vega/vega/wiki/Runtime#view-component-api) | The visualization view. |
+| `options`       | Object         | Options to customize the tooltip. See [options](#options) for details. |
 
 
-## Options
-<!-- TODO(zening): The complete structure of options is now documented in our "APIs" page (docs/APIs.md#options). We can use this section to give some concrete examples of using options to customize fields. (issue #40)-->
+# [vl.tooltip](#vltooltip)
 
-Here is a template of `options`. All of its properties are optional. `options` itself is optional too.
+`vl.tooltip(vgView, vlSpec[, options])`
+
+| Parameter       | Type           | Description     |
+| :-------------- |:--------------:| :-------------- |
+| `vgView`        | [Vega View](https://github.com/vega/vega/wiki/Runtime#view-component-api) | The visualization view. |
+| `vlSpec`        | Object         | The Vega-Lite specification of the visualization. |
+| `options`       | Object         | Options to customize the tooltip. See [options](#options) for details. |
+
+
+# [options](#options)
+
+`options` can customize the content and look of the tooltip. Here is a template of `options`. All of its properties are optional.
 
 ```js
 var options =
@@ -55,7 +45,7 @@ var options =
 | :-------------- |:--------------:| :-------------- |
 | `showAllFields` | Boolean        | If `true`, show all data fields of a visualization in the tooltip. If `false`, only show fields specified in the `fields` array in the tooltip. <br>__Default value:__ `true`|
 | `fields`        | Array          | An array of fields to be displayed in the tooltip when `showAllFields` is `false`. |
-| `colorTheme`    | String         | A color theme picker. <br>__Supported values:__ `"light"` and `"dark"`. <br>__Default value:__ `"light"` <br>To further customize, overwrite the `.vg-tooltip` class in your CSS. |
+| `colorTheme`    | String         | A color theme picker. <br>__Supported values:__ `"light"` and `"dark"`. <br>__Default value:__ `"light"` <br>To further customize, overwrite the `.vl-tooltip` class in your CSS. |
 
 > Tip: You can customize the order of the fields in your tooltip by setting `showAllFields` to `false` and providing a `fields` array. Your tooltip will display fields in the order they appear in the `fields` array.
 

--- a/docs/creating_your_tooltip.md
+++ b/docs/creating_your_tooltip.md
@@ -83,7 +83,7 @@ In your HTML `<body>`, create a placeholder for the tooltip. Give the placeholde
 
 For [Vega-Lite](https://vega.github.io/vega-lite/):
 
-You can create your tooltip using [`vl.tooltip`](docs/APIs.md#vltooltip). This function requires the [`Vega View`](https://github.com/vega/vega/wiki/Runtime#view-component-api) and the original Vega-Lite specification as inputs.
+You can create your tooltip using [`vl.tooltip`](APIs.md#vltooltip). This function requires the [`Vega View`](https://github.com/vega/vega/wiki/Runtime#view-component-api) and the original Vega-Lite specification as inputs.
 
 ```js
 var embedSpec = {
@@ -98,7 +98,7 @@ vg.embed("#vis-scatter", embedSpec, function(error, result) {
 
 For [Vega](http://vega.github.io/vega/):
 
-You can create your tooltip using [`vg.tooltip`](docs/APIs.md#vgtooltip). This function only requires the [`Vega View`](https://github.com/vega/vega/wiki/Runtime#view-component-api) as input.
+You can create your tooltip using [`vg.tooltip`](APIs.md#vgtooltip). This function only requires the [`Vega View`](https://github.com/vega/vega/wiki/Runtime#view-component-api) as input.
 
 ```js
 vg.parse.spec(vgSpec, function(error, chart) {

--- a/docs/creating_your_tooltip.md
+++ b/docs/creating_your_tooltip.md
@@ -5,17 +5,17 @@
 We recommend installing the tooltip library and its dependencies via [`npm`](https://www.npmjs.com/):
 
 ```bash
-npm install vega-lite-tooltip
+npm install vega-tooltip
 ```
 
 The tooltip library contains a `js` file and a `css` file:
 
 ```
-node_modules/vega-lite-tooltip/vl-tooltip.min.js
-node_modules/vega-lite-tooltip/vl-tooltip.css
+node_modules/vega-tooltip/vg-tooltip.min.js
+node_modules/vega-tooltip/vg-tooltip.css
 ```
 
-Alternatively, if you want to manually include the tooltip library and its dependencies, you can add the following lines to your HTML `<head>`. Vega-Lite Tooltip depends on [`d3`](https://d3js.org/), [`vega`](https://vega.github.io/vega/), [`vega-lite`](https://vega.github.io/vega-lite/), [`vega-embed`](https://github.com/vega/vega-embed) and [`datalib`](http://vega.github.io/datalib/).
+Alternatively, if you want to manually include the tooltip library and its dependencies, you can add the following lines to your HTML `<head>`. Vega Tooltip depends on [`d3`](https://d3js.org/), [`vega`](https://vega.github.io/vega/), [`vega-lite`](https://vega.github.io/vega-lite/), [`vega-embed`](https://github.com/vega/vega-embed) and [`datalib`](http://vega.github.io/datalib/).
 
 ```html
 <!-- Dependencies -->
@@ -25,9 +25,9 @@ Alternatively, if you want to manually include the tooltip library and its depen
 <script src="https://vega.github.io/vega-editor/vendor/vega-embed.min.js"></script>
 <script src="https://vega.github.io/datalib/datalib.min.js"></script>
 
-<!-- Vega-Lite Tooltip -->
-<script src="https://vega.github.io/vega-lite-tooltip/vl-tooltip.min.js"></script>
-<link rel="stylesheet" type="text/css" href="https://vega.github.io/vega-lite-tooltip/vl-tooltip.css">
+<!-- Vega Tooltip -->
+<script src="https://vega.github.io/vega-tooltip/vg-tooltip.min.js"></script>
+<link rel="stylesheet" type="text/css" href="https://vega.github.io/vega-tooltip/vg-tooltip.css">
 ```
 <br>
 
@@ -70,11 +70,11 @@ vg.parse.spec(vgSpec, function(error, chart) {
 
 ## Step 3. Create A Tooltip
 
-In your HTML `<body>`, create a placeholder for the tooltip. Give the placeholder an `id` named `vis-tooltip` so that it can be recognized by our plugin. Assign `class` `vl-tooltip` to the tooltip placeholder so that it can pick up the default CSS style our library provides.
+In your HTML `<body>`, create a placeholder for the tooltip. Give the placeholder an `id` named `vis-tooltip` so that it can be recognized by our plugin. Assign `class` `vg-tooltip` to the tooltip placeholder so that it can pick up the default CSS style our library provides.
 
 ```html
 <!-- Placeholder for the tooltip -->
-<div id="vis-tooltip" class="vl-tooltip"></div>
+<div id="vis-tooltip" class="vg-tooltip"></div>
 ```
 
 > Tip: Generally speaking you will only need one tooltip placeholder per page because the mouse typically only points to one thing at a time. If you have more than one visualizations in a page, the visualizations will share one tooltip placeholder.
@@ -83,7 +83,7 @@ In your HTML `<body>`, create a placeholder for the tooltip. Give the placeholde
 
 For [Vega-Lite](https://vega.github.io/vega-lite/):
 
-You can create your tooltip using [`vl.tooltip`](https://github.com/vega/vega-lite-tooltip/wiki/APIs#vltooltip). This function requires the [`Vega View`](https://github.com/vega/vega/wiki/Runtime#view-component-api) and the original Vega-Lite specification as inputs.
+You can create your tooltip using [`vl.tooltip`](https://github.com/vega/vega-tooltip/wiki/APIs#vltooltip). This function requires the [`Vega View`](https://github.com/vega/vega/wiki/Runtime#view-component-api) and the original Vega-Lite specification as inputs.
 
 ```js
 var embedSpec = {
@@ -98,7 +98,7 @@ vg.embed("#vis-scatter", embedSpec, function(error, result) {
 
 For [Vega](http://vega.github.io/vega/):
 
-You can create your tooltip using [`vg.tooltip`](https://github.com/vega/vega-lite-tooltip/wiki/APIs#vgtooltip). This function only requires the [`Vega View`](https://github.com/vega/vega/wiki/Runtime#view-component-api) as input.
+You can create your tooltip using [`vg.tooltip`](https://github.com/vega/vega-tooltip/wiki/APIs#vgtooltip). This function only requires the [`Vega View`](https://github.com/vega/vega/wiki/Runtime#view-component-api) as input.
 
 ```js
 vg.parse.spec(vgSpec, function(error, chart) {

--- a/docs/creating_your_tooltip.md
+++ b/docs/creating_your_tooltip.md
@@ -83,7 +83,7 @@ In your HTML `<body>`, create a placeholder for the tooltip. Give the placeholde
 
 For [Vega-Lite](https://vega.github.io/vega-lite/):
 
-You can create your tooltip using [`vl.tooltip`](https://github.com/vega/vega-tooltip/wiki/APIs#vltooltip). This function requires the [`Vega View`](https://github.com/vega/vega/wiki/Runtime#view-component-api) and the original Vega-Lite specification as inputs.
+You can create your tooltip using [`vl.tooltip`](docs/APIs.md#vltooltip). This function requires the [`Vega View`](https://github.com/vega/vega/wiki/Runtime#view-component-api) and the original Vega-Lite specification as inputs.
 
 ```js
 var embedSpec = {
@@ -98,7 +98,7 @@ vg.embed("#vis-scatter", embedSpec, function(error, result) {
 
 For [Vega](http://vega.github.io/vega/):
 
-You can create your tooltip using [`vg.tooltip`](https://github.com/vega/vega-tooltip/wiki/APIs#vgtooltip). This function only requires the [`Vega View`](https://github.com/vega/vega/wiki/Runtime#view-component-api) as input.
+You can create your tooltip using [`vg.tooltip`](docs/APIs.md#vgtooltip). This function only requires the [`Vega View`](https://github.com/vega/vega/wiki/Runtime#view-component-api) as input.
 
 ```js
 vg.parse.spec(vgSpec, function(error, chart) {

--- a/docs/customizing_your_tooltip.md
+++ b/docs/customizing_your_tooltip.md
@@ -29,7 +29,7 @@ vg.parse.spec(vgSpec, function(error, chart) {
 
 
 ## Options
-<!-- TODO(zening): The complete structure of options is now documented in our "APIs" page (https://github.com/vega/vega-lite-tooltip/wiki/APIs#options). We can use this section to give some concrete examples of using options to customize fields. (issue #40)-->
+<!-- TODO(zening): The complete structure of options is now documented in our "APIs" page (https://github.com/vega/vega-tooltip/wiki/APIs#options). We can use this section to give some concrete examples of using options to customize fields. (issue #40)-->
 
 Here is a template of `options`. All of its properties are optional. `options` itself is optional too.
 
@@ -55,7 +55,7 @@ var options =
 | :-------------- |:--------------:| :-------------- |
 | `showAllFields` | Boolean        | If `true`, show all data fields of a visualization in the tooltip. If `false`, only show fields specified in the `fields` array in the tooltip. <br>__Default value:__ `true`|
 | `fields`        | Array          | An array of fields to be displayed in the tooltip when `showAllFields` is `false`. |
-| `colorTheme`    | String         | A color theme picker. <br>__Supported values:__ `"light"` and `"dark"`. <br>__Default value:__ `"light"` <br>To further customize, overwrite the `.vl-tooltip` class in your CSS. |
+| `colorTheme`    | String         | A color theme picker. <br>__Supported values:__ `"light"` and `"dark"`. <br>__Default value:__ `"light"` <br>To further customize, overwrite the `.vg-tooltip` class in your CSS. |
 
 > Tip: You can customize the order of the fields in your tooltip by setting `showAllFields` to `false` and providing a `fields` array. Your tooltip will display fields in the order they appear in the `fields` array.
 

--- a/examples.js
+++ b/examples.js
@@ -12,6 +12,9 @@
         spec: vlSpec
       };
       vg.embed(id, embedSpec, function(error, result) {
+        if (error) {
+          return console.error(error);
+        }
         vl.tooltip(result.view, vlSpec, options);
       });
     });
@@ -20,7 +23,7 @@
   function addVgExample(path, id, options) {
     d3.json(path, function(error, vgSpec) {
       if (error) {
-        return console.warn(error);
+        return console.error(error);
       }
       vg.parse.spec(vgSpec, function(error, chart) {
         var view = chart({el:id}).update();

--- a/index.html
+++ b/index.html
@@ -11,8 +11,8 @@
   <script src="node_modules/datalib/datalib.min.js"></script>
 
   <!-- Tooltip Library -->
-  <script src="src/vl-tooltip.js"></script>
-  <link rel="stylesheet" type="text/css" href="src/vl-tooltip.css">
+  <script src="src/vg-tooltip.js"></script>
+  <link rel="stylesheet" type="text/css" href="src/vg-tooltip.css">
 
   <!-- Example Page -->
   <script src="examples.js"></script>
@@ -70,7 +70,7 @@
   <div id="vis-heatmap" class="tooltip-example"></div>
 
   <!-- Placeholder for Tooltip -->
-  <div id="vis-tooltip" class="vl-tooltip"></div>
+  <div id="vis-tooltip" class="vg-tooltip"></div>
 
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "vega-lite-tooltip",
+  "name": "vega-tooltip",
   "version": "0.1.0",
   "description": "A tooltip plugin for vega-lite and vega visualizations.",
-  "main": "src/vl-tooltip.js",
+  "main": "src/vg-tooltip.js",
   "scripts": {
     "prebuild": "npm run data",
-    "build": "uglifyjs src/vl-tooltip.js -cm > vl-tooltip.min.js && cp src/vl-tooltip.css vl-tooltip.css",
+    "build": "uglifyjs src/vg-tooltip.js -cm > vg-tooltip.min.js && cp src/vg-tooltip.css vg-tooltip.css",
     "data": "rsync -r node_modules/vega-datasets/data/* data",
     "start": "npm run build && python -m SimpleHTTPServer 4000"
   },
@@ -20,7 +20,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vega/vega-lite-tooltip.git"
+    "url": "git+https://github.com/vega/vega-tooltip.git"
   },
   "keywords": [
     "vega-lite",
@@ -30,7 +30,7 @@
   "author": "Zening Qu",
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/vega/vega-lite-tooltip/issues"
+    "url": "https://github.com/vega/vega-tooltip/issues"
   },
-  "homepage": "https://github.com/vega/vega-lite-tooltip#readme"
+  "homepage": "https://github.com/vega/vega-tooltip#readme"
 }

--- a/src/vg-tooltip.css
+++ b/src/vg-tooltip.css
@@ -1,4 +1,4 @@
-.vl-tooltip {
+.vg-tooltip {
   display: none;
   padding: 6px;
   border-radius: 3px;
@@ -13,35 +13,35 @@
   border: 1px solid #d9d9d9;
   color: black;
 }
-.vl-tooltip td.key, .vl-tooltip td.value {
+.vg-tooltip td.key, .vg-tooltip td.value {
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.vl-tooltip td.key {
+.vg-tooltip td.key {
   color: #808080;
   max-width: 150px;
   text-align: right;
   padding-right: 1px;
 }
-.vl-tooltip td.value {
+.vg-tooltip td.value {
   max-width: 200px;
   text-align: left;
 }
 
 /* Dark and light color themes */
-.vl-tooltip.dark-theme {
+.vg-tooltip.dark-theme {
   background-color: rgba(64, 64, 64, 0.9);
   border: none;
   color: white;
 }
-.vl-tooltip.dark-theme td.key {
+.vg-tooltip.dark-theme td.key {
   color: #bfbfbf;
 }
-.vl-tooltip.light-theme {
+.vg-tooltip.light-theme {
   background-color: rgba(255, 255, 255, 0.9);
   border: 1px solid #d9d9d9;
   color: black;
 }
-.vl-tooltip.light-theme td.key {
+.vg-tooltip.light-theme td.key {
   color: #808080;
 }

--- a/src/vg-tooltip.js
+++ b/src/vg-tooltip.js
@@ -2,7 +2,7 @@
 
 (function() {
   /**
-  * Export Vega Tooltip API: vg.tooltip(vgView, options)
+  * Export API for Vega visualizations: vg.tooltip(vgView, options)
   * options can specify whether to show all fields or to show only custom fields
   * It can also provide custom title and format for fields
   */
@@ -30,7 +30,7 @@
   };
 
   /**
-  * Export Vega-Lite Tooltip API: vl.tooltip(vgView, vlSpec, options)
+  * Export API for Vega-Lite visualizations: vl.tooltip(vgView, vlSpec, options)
   * options can specify whether to show all fields or to show only custom fields
   * It can also provide custom title and format for fields
   * options can be supplemented by vlSpec

--- a/src/vg-tooltip.js
+++ b/src/vg-tooltip.js
@@ -244,7 +244,9 @@
       switch (supplementedFieldOption.formatType) {
         case "time":
           supplementedFieldOption.format = fieldDef.timeUnit ?
-            vl.timeUnit.format(fieldDef.timeUnit) : timeFormat;
+            // TODO(zening): use template for all time fields, to be consistent with Vega-Lite
+            vl.timeUnit.template(fieldDef.timeUnit, "", false).match(/time:'[%-a-z]*'/i)[0].split("'")[1]
+            : timeFormat;
           break;
         case "number":
           supplementedFieldOption.format = numberFormat;


### PR DESCRIPTION
Renamed package name to `vega-tooltip` in code and documentation.

Added a temporary fix for timeUnit template (to make examples in this PR work). We will use template for all time fields in a different PR.