### PR TITLE
Tooltip on overlay line charts and area charts

### DIFF
--- a/exampleSpecs/overlay_area_full.json
+++ b/exampleSpecs/overlay_area_full.json
@@ -1,0 +1,29 @@
+{
+  "description": "Google's stock price over time.",
+  "data": {"url": "data/stocks.csv","format": {"type": "csv"}},
+  "transform": {"filter": "datum.symbol==='GOOG'"},
+  "layers": [
+    {
+      "mark": "area",
+      "encoding": {
+        "x": {"field": "date","type": "temporal"},
+        "y": {"field": "price","type": "quantitative"}
+      }
+    },
+    {
+      "mark": "line",
+      "encoding": {
+        "x": {"field": "date","type": "temporal"},
+        "y": {"field": "price","type": "quantitative"}
+      }
+    },
+    {
+      "mark": "point",
+      "encoding": {
+        "x": {"field": "date","type": "temporal"},
+        "y": {"field": "price","type": "quantitative"}
+      },
+      "config": {"mark": {"filled": true}}
+    }
+  ]
+}

--- a/exampleSpecs/overlay_area_short.json
+++ b/exampleSpecs/overlay_area_short.json
@@ -1,0 +1,11 @@
+{
+  "description": "Google's stock price over time.",
+  "data": {"url": "data/stocks.csv", "format": {"type": "csv"}},
+  "transform": {"filter": "datum.symbol==='GOOG'"},
+  "mark": "area",
+  "encoding": {
+    "x": {"field": "date", "type": "temporal"},
+    "y": {"field": "price", "type": "quantitative"}
+  },
+  "config": {"overlay": {"area": "linepoint"}}
+}

--- a/exampleSpecs/overlay_line_full.json
+++ b/exampleSpecs/overlay_line_full.json
@@ -1,0 +1,25 @@
+{
+  "data": {"url": "data/stocks.csv","format": {"type": "csv"}},
+  "transform": {"filter": "datum.symbol==='GOOG'"},
+  "layers": [
+    {
+      "description": "Google's stock price over time.",
+      "mark": "line",
+      "encoding": {
+        "x": {"field": "date","type": "temporal"},
+        "y": {"field": "price","type": "quantitative"},
+        "color": {"field": "symbol", "type": "nominal"}
+      }
+    },
+    {
+      "description": "Google's stock price over time.",
+      "mark": "point",
+      "encoding": {
+        "x": {"field": "date","type": "temporal"},
+        "y": {"field": "price","type": "quantitative"},
+        "color": {"field": "symbol", "type": "nominal"}
+      },
+      "config": {"mark": {"filled": true}}
+    }
+  ]
+}

--- a/exampleSpecs/overlay_line_short.json
+++ b/exampleSpecs/overlay_line_short.json
@@ -1,0 +1,12 @@
+{
+  "description": "Google's stock price over time.",
+  "data": {"url": "data/stocks.csv", "format": {"type": "csv"}},
+  "transform": {"filter": "datum.symbol==='GOOG'"},
+  "mark": "line",
+  "encoding": {
+    "x": {"field": "date", "type": "temporal"},
+    "y": {"field": "price", "type": "quantitative"},
+    "color": {"field": "symbol", "type": "nominal"}
+  },
+  "config": {"overlay": {"line": true}}
+}

--- a/examples.js
+++ b/examples.js
@@ -106,18 +106,33 @@
   // Layered Bar Chart
   addVlExample("exampleSpecs/bar_layered_transparent.json", "#vis-layered-bar");
 
-  // Line Chart
-  var lineOpts = {
-    colorTheme: "dark"
-  }
-  addVlExample("exampleSpecs/line.json", "#vis-line", lineOpts);
-
   // Colored Line Chart
   var colorLineOpts = {}
   addVlExample("exampleSpecs/line_color.json", "#vis-color-line", colorLineOpts);
 
-  // Area Chart
-  addVlExample("exampleSpecs/area_vertical.json", "#vis-area-vertical");
+  // Overlay Line Chart
+  var overlayLineOpts = {
+    fields: [
+      {
+        field: "date",
+        formatType: "time",
+        format: "%Y-%m-%d"
+      }
+    ]
+  }
+  addVlExample("exampleSpecs/overlay_line_short.json", "#vis-overlay-line", overlayLineOpts);
+
+  // Overlay Area Chart
+  var overlayAreaOpts = {
+    fields: [
+      {
+        field: "date",
+        formatType: "time",
+        format: "%Y-%m-%d"
+      }
+    ]
+  }
+  addVlExample("exampleSpecs/overlay_area_short.json", "#vis-overlay-area", overlayAreaOpts);
 
 
   /* Vega Examples */

--- a/index.html
+++ b/index.html
@@ -44,16 +44,14 @@
   <!-- Layered Bar Chart -->
   <div id="vis-layered-bar" class="tooltip-example"></div>
 
-
-  <!-- TODO(zening): use vega-lite layering to support line charts and area charts (issue #1) -->
-  <!-- Line Chart -->
-  <div id="vis-line" class="tooltip-example"></div>
-
   <!-- Color Line Chart -->
   <div id="vis-color-line" class="tooltip-example"></div>
 
-  <!-- Area Chart -->
-  <div id="vis-area-vertical" class="tooltip-example"></div>
+  <!-- Overlay Line Chart -->
+  <div id="vis-overlay-line" class="tooltip-example"></div>
+
+  <!-- Overlay Area Chart -->
+  <div id="vis-overlay-area" class="tooltip-example"></div>
 
 
   <h1>Vega Tooltip Examples</h1>

--- a/src/vg-tooltip.js
+++ b/src/vg-tooltip.js
@@ -513,29 +513,18 @@
   }
 
   /**
-  * Drop fields for line charts and area charts.
+  * Drop fields for line and area marks.
   *
-  * Lines and areas are defined by a series of datum. Without layering, tooltip
-  * will only show one datum per line / area mark. As a partial fix, we drop
-  * quantitative fields for line charts and area charts. This is the current
-  * implementation of the function.
-  *
-  * This doesn't completely solve the problem: if a data set contains a field
-  * that is not used for encoding, it will still show up in the tooltip and
-  * confuse users. The additional qualitative field's value may vary for a line
-  * or area mark but tooltip will only be able to show one value. As a better
-  * partial fix, we may drop fields in the x and y channels and only show fields
-  * in the other channels (typically color). In this way, if a qualitative field
-  * is not used for encoding, it will not show up in the tooltip.
-  *
-  * Eventually, we will use vega-lite layering to properly show all fields.
+  * Lines and areas are defined by a series of datum. We overlay point marks 
+  * on top of lines and areas to allow tooltip to show all data in the series.
+  * For the line marks and area marks underneath, we only show nominal fields
+  * in tooltip. This is because line / area marks only give us the last datum 
+  * in their series. It only make sense to show the nominal fields (e.g., symbol
+  * = APPL, AMZN, GOOG, IBM, MSFT) because these fields don't tend to change along
+  * the line / area border.
   */
-  // TODO(zening): use vega-lite layering to support tooltip on line charts and area charts (issue #1)
-  // TODO(zening): change the logic from drop quant fields to only show non-x-y fields in fieldDefs
   function dropFieldsForLineArea(marktype, itemData) {
     if (marktype === "line" || marktype === "area") {
-      console.warn("[Tooltip]: By default, we only show qualitative data for " + marktype + " charts.");
-
       var quanKeys = [];
       itemData.forEach(function(field, value) {
         switch (dl.type(value)) {


### PR DESCRIPTION
Please merge #46 first. Branch-wise difference: https://github.com/vega/vega-tooltip/compare/zqu/rename...zqu/tooltip-on-layers

Tooltip is now working with `overlay` config for `line` and `area`. Fix #47 

For line chart, when hovering on the points, we get all fields in tooltip:
![line](https://cloud.githubusercontent.com/assets/822034/17114417/b8f63bc2-5263-11e6-8071-73e0911469ee.png)

When hovering on the line, we only get the string and boolean fields in tooltip:
![line2](https://cloud.githubusercontent.com/assets/822034/17114684/d16b7ff4-5264-11e6-8c99-94f0a51fcebb.png)

Similarly, when hovering on the points on top of an area, we get all fields:
![area](https://cloud.githubusercontent.com/assets/822034/17114714/ec1281b8-5264-11e6-9d94-10b32c518da6.png)

When hovering on the area itself, we only get the string and boolean fields:
![area2](https://cloud.githubusercontent.com/assets/822034/17114717/f6529a46-5264-11e6-9063-f9352e64c8a1.png)


