### PR TITLE
Accept onAppear, onMove, onDisappear callbacks through options

### DIFF
--- a/docs/APIs.md
+++ b/docs/APIs.md
@@ -41,6 +41,9 @@ var options =
     },
     ...
   }],
+  onAppear: function(event, item) { /* callback */ },
+  onMove: function(event, item) { /* callback */ },
+  onDisappear: function(event, item) { /* callback */ },
   colorTheme: "light" | "dark"
 };
 ```
@@ -50,6 +53,9 @@ var options =
 | `showAllFields` | Boolean        | If `true`, show all data fields of a visualization in the tooltip. If `false`, only show fields specified in the `fields` array in the tooltip. <br>__Default value:__ `true`|
 | `fields`        | Array          | An array of fields to be displayed in the tooltip when `showAllFields` is `false`. |
 | `colorTheme`    | String         | A color theme picker. <br>__Supported values:__ `"light"` and `"dark"`. <br>__Default value:__ `"light"` <br>To further customize, overwrite the `.vl-tooltip` class in your CSS. |
+| `onAppear`      | function(event, item) | Callback when tooltip first appears (when mouse moves over a new item in visualization). |
+| `onMove`        | function(event, item) | Callback when tooltip moves (e.g., when mouse moves within a bar). |
+| `onDisappear`   | function(event, item) | Callback when tooltip disappears (when mouse moves out an item). |
 
 > Tip: You can customize the order of the fields in your tooltip by setting `showAllFields` to `false` and providing a `fields` array. Your tooltip will display fields in the order they appear in the `fields` array.
 

--- a/src/vg-tooltip.js
+++ b/src/vg-tooltip.js
@@ -25,7 +25,7 @@
 
     // clear tooltip on mouse out
     vgView.on("mouseout.tooltipClear", function(event, item) {
-      clear();
+      clear(event, item, options);
     });
 
     return {
@@ -64,7 +64,7 @@
 
     // clear tooltip on mouse out
     vgView.on("mouseout.tooltipClear", function(event, item) {
-      clear();
+      clear(event, item, options);
     });
 
     return {
@@ -287,7 +287,7 @@
 
   /* Initialize tooltip with data */
   function init(event, item, options) {
-    if( shouldShowTooltip(item) === false ) return;
+    if ( shouldShowTooltip(item) === false ) return;
 
     // get tooltip HTML placeholder
     var tooltipPlaceholder = getTooltipPlaceholder();
@@ -302,15 +302,27 @@
     updatePosition(event, options);
     updateColorTheme(options);
     d3.select("#vis-tooltip").style("display", "block");
+
+    if (options.onInit) {
+      options.onInit(event, item);
+    }
   }
 
   /* Update tooltip position on mousemove */
   function update(event, item, options) {
     updatePosition(event, options);
+
+    if (options.onUpdate) {
+      options.onUpdate(event, item);
+    }
   }
 
   /* Clear tooltip */
-  function clear() {
+  function clear(event, item, options) {
+    if (options.onClear) {
+      options.onClear(event, item);
+    }
+
     clearData();
     clearColorTheme();
     d3.select("#vis-tooltip").style("display", "none");
@@ -456,7 +468,7 @@
     itemData.forEach(function(field, value) {
       // prepare title
       var title;
-      if(fieldOptions.has(field) && fieldOptions.get(field).title) {
+      if (fieldOptions.has(field) && fieldOptions.get(field).title) {
         title = fieldOptions.get(field).title;
       }
       else {

--- a/src/vg-tooltip.js
+++ b/src/vg-tooltip.js
@@ -314,8 +314,8 @@
     d3.select("#vis-tooltip").style("display", "block");
 
     // invoke user-provided callback
-    if (options.onInit) {
-      options.onInit(event, item);
+    if (options.onAppear) {
+      options.onAppear(event, item);
     }
   }
 
@@ -324,8 +324,8 @@
     updatePosition(event, options);
 
     // invoke user-provided callback
-    if (options.onUpdate) {
-      options.onUpdate(event, item);
+    if (options.onMove) {
+      options.onMove(event, item);
     }
   }
 
@@ -336,8 +336,8 @@
     d3.select("#vis-tooltip").style("display", "none");
 
     // invoke user-provided callback
-    if (options.onClear) {
-      options.onClear(event, item);
+    if (options.onDisappear) {
+      options.onDisappear(event, item);
     }
   }
 

--- a/src/vg-tooltip.js
+++ b/src/vg-tooltip.js
@@ -14,18 +14,24 @@
 
     // initialize tooltip with item data and options on mouse over
     vgView.on("mouseover.tooltipInit", function(event, item) {
-      init(event, item, options);
+      if (shouldShowTooltip(item)) {
+        init(event, item, options);
+      }
     });
 
     // update tooltip position on mouse move
     // (important for large marks e.g. bars)
     vgView.on("mousemove.tooltipUpdate", function(event, item) {
-      update(event, item, options);
+      if (shouldShowTooltip(item)) {
+        update(event, item, options);
+      }
     });
 
     // clear tooltip on mouse out
     vgView.on("mouseout.tooltipClear", function(event, item) {
-      clear(event, item, options);
+      if (shouldShowTooltip(item)) {
+        clear(event, item, options);
+      }
     });
 
     return {
@@ -53,18 +59,24 @@
 
     // initialize tooltip with item data and options on mouse over
     vgView.on("mouseover.tooltipInit", function(event, item) {
-      init(event, item, options);
+      if (shouldShowTooltip(item)) {
+        init(event, item, options);
+      }
     });
 
     // update tooltip position on mouse move
     // (important for large marks e.g. bars)
     vgView.on("mousemove.tooltipUpdate", function(event, item) {
-      update(event, item, options);
+      if (shouldShowTooltip(item)) {
+        update(event, item, options);
+      }
     });
 
     // clear tooltip on mouse out
     vgView.on("mouseout.tooltipClear", function(event, item) {
-      clear(event, item, options);
+      if (shouldShowTooltip(item)) {
+        clear(event, item, options);
+      }
     });
 
     return {
@@ -287,8 +299,6 @@
 
   /* Initialize tooltip with data */
   function init(event, item, options) {
-    if ( shouldShowTooltip(item) === false ) return;
-
     // get tooltip HTML placeholder
     var tooltipPlaceholder = getTooltipPlaceholder();
 
@@ -303,6 +313,7 @@
     updateColorTheme(options);
     d3.select("#vis-tooltip").style("display", "block");
 
+    // invoke user-provided callback
     if (options.onInit) {
       options.onInit(event, item);
     }
@@ -312,6 +323,7 @@
   function update(event, item, options) {
     updatePosition(event, options);
 
+    // invoke user-provided callback
     if (options.onUpdate) {
       options.onUpdate(event, item);
     }
@@ -319,13 +331,14 @@
 
   /* Clear tooltip */
   function clear(event, item, options) {
-    if (options.onClear) {
-      options.onClear(event, item);
-    }
-
     clearData();
     clearColorTheme();
     d3.select("#vis-tooltip").style("display", "none");
+
+    // invoke user-provided callback
+    if (options.onClear) {
+      options.onClear(event, item);
+    }
   }
 
 


### PR DESCRIPTION
Allow user to provide `onInit`, `onUpdate` and `onClear` callbacks through `options`
- [x] `onAppear(event, item)`, `onMove(event, item)`, `onDisappear(event, item)`
- [x] Check `ShouldShowTooltip(item)` on mouseover, mousemove and mouseout
  - This makes sure that user-provided callbacks only get called on items that actually has tooltip. If it's some random chart element that doesn't deserve a tooltip, we don't call user-provided callbacks.
- [x] Update doc
- [x] Test with vlui (https://github.com/vega/vega-lite-ui/pull/239/commits/f0ecd4a9f8e34a892112b8142d7865900a0308d0) and voyager2