### PR TITLE
Add delay in tooltip

### DIFF
--- a/docs/APIs.md
+++ b/docs/APIs.md
@@ -41,6 +41,7 @@ var options =
     },
     ...
   }],
+  delay: 250,
   onAppear: function(event, item) { /* callback */ },
   onMove: function(event, item) { /* callback */ },
   onDisappear: function(event, item) { /* callback */ },
@@ -52,10 +53,11 @@ var options =
 | :-------------- |:--------------:| :-------------- |
 | `showAllFields` | Boolean        | If `true`, show all data fields of a visualization in the tooltip. If `false`, only show fields specified in the `fields` array in the tooltip. <br>__Default value:__ `true`|
 | `fields`        | Array          | An array of fields to be displayed in the tooltip when `showAllFields` is `false`. |
-| `colorTheme`    | String         | A color theme picker. <br>__Supported values:__ `"light"` and `"dark"`. <br>__Default value:__ `"light"` <br>To further customize, overwrite the `.vl-tooltip` class in your CSS. |
+| `delay`         | Number         | Number of milliseconds tooltip display should be delayed. <br>__Default value:__ 100 milliseconds.|
 | `onAppear`      | function(event, item) | Callback when tooltip first appears (when mouse moves over a new item in visualization). |
 | `onMove`        | function(event, item) | Callback when tooltip moves (e.g., when mouse moves within a bar). |
 | `onDisappear`   | function(event, item) | Callback when tooltip disappears (when mouse moves out an item). |
+| `colorTheme`    | String         | A color theme picker. <br>__Supported values:__ `"light"` and `"dark"`. <br>__Default value:__ `"light"` <br>To further customize, overwrite the `.vl-tooltip` class in your CSS. |
 
 > Tip: You can customize the order of the fields in your tooltip by setting `showAllFields` to `false` and providing a `fields` array. Your tooltip will display fields in the order they appear in the `fields` array.
 

--- a/examples.js
+++ b/examples.js
@@ -63,7 +63,16 @@
         formatType: "number",
         format: ".2f"
       }
-    ]
+    ],
+    onAppear: function() {
+      console.log("tooltip appears!");
+    },
+    onDisappear: function() {
+      console.log("tooltip disappears!");
+    },
+    onMove: function() {
+      console.log("tooltip moves!");
+    }
   }
   addVlExample("exampleSpecs/bubble_multiple_aggregation.json", "#vis-bubble-multi-aggr", bubbleOpts);
 
@@ -154,7 +163,16 @@
         formatType: "number",
         format: ".1%"
       }
-    ]
+    ],
+    onAppear: function() {
+      console.log("tooltip appears!");
+    },
+    onDisappear: function() {
+      console.log("tooltip disappears!");
+    },
+    onMove: function() {
+      console.log("tooltip moves!");
+    }
   }
   addVgExample("exampleSpecs/choropleth.json", "#vis-choropleth", choroplethOpts);
 

--- a/src/vg-tooltip.css
+++ b/src/vg-tooltip.css
@@ -1,5 +1,5 @@
 .vg-tooltip {
-  display: none;
+  visibility: hidden;
   padding: 6px;
   border-radius: 3px;
   position: fixed;

--- a/src/vg-tooltip.js
+++ b/src/vg-tooltip.js
@@ -52,9 +52,12 @@
 
     return {
       destroy: function() {
+        // remove event listeners
         vgView.off("mouseover.tooltipInit");
         vgView.off("mousemove.tooltipUpdate");
         vgView.off("mouseout.tooltipClear");
+
+        cancelPromise(); // clear tooltip promise
       }
     }
   };
@@ -109,9 +112,12 @@
 
     return {
       destroy: function() {
+        // remove event listeners
         vgView.off("mouseover.tooltipInit");
         vgView.off("mousemove.tooltipUpdate");
         vgView.off("mouseout.tooltipClear");
+
+        cancelPromise(); // clear tooltip promise
       }
     }
   };

--- a/src/vg-tooltip.js
+++ b/src/vg-tooltip.js
@@ -25,7 +25,6 @@
 
         tooltipPromise = window.setTimeout(function() {
           init(event, item, options);
-          tooltipActive = true;
         }, options.delay || DELAY);
       }
     });
@@ -45,7 +44,6 @@
 
         if (tooltipActive) {
           clear(event, item, options);
-          tooltipActive = false;
         }
       }
     });
@@ -85,7 +83,6 @@
         // make a new promise with time delay for tooltip
         tooltipPromise = window.setTimeout(function() {
           init(event, item, options);
-          tooltipActive = true;
         }, options.delay || DELAY);
       }
     });
@@ -105,7 +102,6 @@
 
         if (tooltipActive) {
           clear(event, item, options);
-          tooltipActive = false;
         }
       }
     });
@@ -352,6 +348,7 @@
     updatePosition(event, options);
     updateColorTheme(options);
     d3.select("#vis-tooltip").style("visibility", "visible");
+    tooltipActive = true;
 
     // invoke user-provided callback
     if (options.onAppear) {
@@ -371,13 +368,13 @@
 
   /* Clear tooltip */
   function clear(event, item, options) {
-    clearData();
-    clearColorTheme();
-
     // visibility hidden instead of display none
     // because we need computed tooltip width and height to best position it
     d3.select("#vis-tooltip").style("visibility", "hidden");
 
+    tooltipActive = false;
+    clearData();
+    clearColorTheme();
     clearPosition();
 
     // invoke user-provided callback

--- a/src/vg-tooltip.js
+++ b/src/vg-tooltip.js
@@ -2,7 +2,7 @@
 
 (function() {
   // by default, delay showing tooltip for 100 ms
-  const DELAY = 100;
+  var DELAY = 100;
   var tooltipPromise = undefined;
   var tooltipActive = false;
 

--- a/src/vg-tooltip.js
+++ b/src/vg-tooltip.js
@@ -64,7 +64,6 @@
       if (shouldShowTooltip(item)) {
         timeoutID = window.setTimeout(function() {
           init(event, item, options);
-          console.log('initiating', timeoutID);
         }, 250);
       }
     });
@@ -318,7 +317,7 @@
 
     updatePosition(event, options);
     updateColorTheme(options);
-    d3.select("#vis-tooltip").style("display", "block");
+    d3.select("#vis-tooltip").style("visibility", "visible");
 
     // invoke user-provided callback
     if (options.onAppear) {
@@ -340,7 +339,10 @@
   function clear(event, item, options) {
     clearData();
     clearColorTheme();
-    d3.select("#vis-tooltip").style("display", "none");
+
+    // visibility hidden instead of display none
+    // because we need computed tooltip width and height to best position it
+    d3.select("#vis-tooltip").style("visibility", "hidden");
 
     // invoke user-provided callback
     if (options.onDisappear) {
@@ -694,7 +696,9 @@
       .style("top", function() {
         // by default: put tooltip 10px below cursor
         // if tooltip is close to the bottom of the window, put tooltip 10px above cursor
-        var tooltipHeight = parseInt(d3.select(this).style("height"));
+        var tooltipHeight = this.getBoundingClientRect().height;
+        console.log("tooltipHeight:", tooltipHeight);
+
         if (event.clientY + tooltipHeight + offsetY < window.innerHeight) {
           return "" + (event.clientY + offsetY) + "px";
         } else {
@@ -704,7 +708,7 @@
       .style("left", function() {
         // by default: put tooltip 10px to the right of cursor
         // if tooltip is close to the right edge of the window, put tooltip 10 px to the left of cursor
-        var tooltipWidth = parseInt(d3.select(this).style("width"));
+        var tooltipWidth = this.getBoundingClientRect().width;
         if (event.clientX + tooltipWidth + offsetX < window.innerWidth) {
           return "" + (event.clientX + offsetX) + "px";
         } else {

--- a/src/vg-tooltip.js
+++ b/src/vg-tooltip.js
@@ -372,6 +372,8 @@
     // because we need computed tooltip width and height to best position it
     d3.select("#vis-tooltip").style("visibility", "hidden");
 
+    clearPosition();
+
     // invoke user-provided callback
     if (options.onDisappear) {
       options.onDisappear(event, item);
@@ -725,7 +727,6 @@
         // by default: put tooltip 10px below cursor
         // if tooltip is close to the bottom of the window, put tooltip 10px above cursor
         var tooltipHeight = this.getBoundingClientRect().height;
-
         if (event.clientY + tooltipHeight + offsetY < window.innerHeight) {
           return "" + (event.clientY + offsetY) + "px";
         } else {
@@ -742,6 +743,13 @@
           return "" + (event.clientX - tooltipWidth - offsetX) + "px";
         }
       });
+  }
+
+  /* Clear tooltip position */
+  function clearPosition() {
+    d3.select("#vis-tooltip")
+      .style("top", "-9999px")
+      .style("left", "-9999px");
   }
 
   /**

--- a/src/vg-tooltip.js
+++ b/src/vg-tooltip.js
@@ -57,10 +57,15 @@
 
     options = supplementOptions(options, vlSpec);
 
+    var timeoutID = undefined;
+
     // initialize tooltip with item data and options on mouse over
     vgView.on("mouseover.tooltipInit", function(event, item) {
       if (shouldShowTooltip(item)) {
-        init(event, item, options);
+        timeoutID = window.setTimeout(function() {
+          init(event, item, options);
+          console.log('initiating', timeoutID);
+        }, 250);
       }
     });
 
@@ -76,6 +81,8 @@
     vgView.on("mouseout.tooltipClear", function(event, item) {
       if (shouldShowTooltip(item)) {
         clear(event, item, options);
+        window.clearTimeout(timeoutID);
+        console.log("clearing", timeoutID);
       }
     });
 

--- a/src/vg-tooltip.js
+++ b/src/vg-tooltip.js
@@ -118,8 +118,11 @@
     }
   };
 
-  // cancel tooltip promise
+  /* Cancel tooltip promise */
   function cancelPromise() {
+    /* We don't check if tooltipPromise is valid because passing
+     an invalid ID to clearTimeout does not have any effect
+     (and doesn't throw an exception). */
     window.clearTimeout(tooltipPromise);
     tooltipPromise = undefined;
   }


### PR DESCRIPTION
- [x] Add delay in tooltip
  - [x] setTimeout on mousemove
  - [x] cancelTimeout on mouseout
  - [x] cancel tooltip promise on tooltip destroy
  - [x] Positioning tooltip: get rendered tooltip height and width instead of height and width style
  - [x] Use `visibility:hidden` instead of `display:none` because we need to know the rendered tooltip height and width to place it in the right position
  - [x] Place tooltip far far away from screen on `clear()`
  - [x] Add test `onAppear`, `onDisappear`, `onMove` callbacks in examples to make sure that these callbacks are executed in the right moments given time delay. For example, `onAppear` callback should be called when tooltip actually becomes visible.
  - [x] Update doc
  - [x] Tested with vlui (https://github.com/vega/vega-lite-ui/pull/239) and voyager2