### PR TITLE
Better display temporal fields in tooltip (with or without timeUnit)

### DIFF
--- a/src/vg-tooltip.js
+++ b/src/vg-tooltip.js
@@ -315,7 +315,7 @@
           supplementedFieldOption.format = fieldDef.timeUnit ?
             // TODO(zening): use template for all time fields, to be consistent with Vega-Lite
             vl.timeUnit.template(fieldDef.timeUnit, "", false).match(/time:'[%-a-z]*'/i)[0].split("'")[1]
-              : config.timeFormat;
+              : config.timeFormat || vl.config.defaultConfig.timeFormat;
           break;
         case "number":
           supplementedFieldOption.format = config.numberFormat;


### PR DESCRIPTION
![no timeunit](https://cloud.githubusercontent.com/assets/822034/18041626/a9c0621e-6d6f-11e6-8698-4e19803cf229.png)
Fig.1

![with timeunit](https://cloud.githubusercontent.com/assets/822034/18041629/adf007f4-6d6f-11e6-8767-8b753862c778.png)
Fig.2

![corner case](https://cloud.githubusercontent.com/assets/822034/18067005/bf1d0a2e-6def-11e6-835f-e5e5950e1fac.png)
Fig.3

Better display temporal fields in tooltip (with or without timeUnit). Fix #54 
- [x] If vlSpec just have a temporal field `T` (without `timeUnit`), use vega-lite default config timeFormat to format T (Fig.1)
- [x] If vlSpec just have `(TIMEUNIT)T`, `item.datum` will contain duplicate temporal fields -- one with timeUnit and one without (e.g., `YEAR(Year)` and `Year`). This PR removes `T` and keeps `(TIMEUNIT)T`for tooltip to display. (Fig.2)
- [x] If vlSpec has both `T` and `(TIMEUNIT)T`, then keep both `T` and `(TIMEUNIT)T` for tooltip to display. (Fig.3)
- [x] When necessary, store T in `removeOriginalTemporalField` in `options`. I thought about making `removeOriginalTemporalField` a boolean, but making it `T` or undefined makes field removal easier, in my opinion... User should never have to provide `removeOriginalTemporalField` in options.
- [x] Tested with Voyager2
- [x] Tested with tooltip examples