### PR TITLE
Use template for temporal fields

### DIFF
--- a/docs/APIs.md
+++ b/docs/APIs.md
@@ -36,7 +36,7 @@ var options =
       field: "field1",
       title: "Field One",
       formatType: "time" | "number" | "string",
-      format: string-specifier,
+      format: String | undefined,
       aggregate: operation,
     },
     ...
@@ -70,7 +70,7 @@ Each member in the `fields` array can customize the format of a field. These cus
 | `field`         | String         | The unique name of the field. With Vega-Lite, this is the field you provided to each encoding channel. |
 | `title`         | String         | A custom title for the field. |
 | `formatType`    | String         | Tells what kind of field this is (for formatting the field value in the tooltip) <br>__Supported values:__ `"number"`, `"time"`, and `"string"`. |
-| `format`        | String         | A string specifier for formatting the field value in the tooltip. If `formatType` is `"number"`, you can provide a [number format string-specifier](https://github.com/mbostock/d3/wiki/Formatting). If `formatType` is `"time"`, you can provide a [time format string-specifier](https://github.com/mbostock/d3/wiki/Time-Formatting). If `formatType` is `"string"`, there is no need to provide a `format`. |
+| `format`        | String         | A string for formatting the field value in the tooltip. If `formatType` is `"number"`, you can provide a [d3 number format specifier](https://github.com/mbostock/d3/wiki/Formatting). If `formatType` is `"time"`, you can provide a [d3 time format specifier](https://github.com/mbostock/d3/wiki/Time-Formatting) or a [vega-lite timeUnit](https://vega.github.io/vega-lite/docs/timeunit.html). If `formatType` is `"string"`, there is no need to provide a `format`. |
 | `aggregate`     | String         | (Vega-Lite only) If your Vega-Lite visualization has multiple aggregations of the same field, you can specify the aggregation to identify the particular aggregated field. <br>__Supported values:__ [Vega-Lite aggregate operations](https://vega.github.io/vega-lite/docs/aggregate.html#supported-aggregation-operations)|
 
 # [tooltip Object](#tooltip)

--- a/docs/customizing_your_tooltip.md
+++ b/docs/customizing_your_tooltip.md
@@ -41,8 +41,8 @@ var options =
     {
       field: "field1",
       title: "Field One",
-      formatType: "time" | "number" | "string", 			
-      format: string-specifier,
+      formatType: "time" | "number" | "string",
+      format: String | undefined,
       aggregate: operation,
     },
     ...
@@ -68,5 +68,5 @@ Each member in the `fields` array can customize the format of a field. These cus
 | `field`         | String         | The unique name of the field. With Vega-Lite, this is the field you provided to each encoding channel. |
 | `title`         | String         | A custom title for the field. |
 | `formatType`    | String         | Tells what kind of field this is (for formatting the field value in the tooltip) <br>__Supported values:__ `"number"`, `"time"`, and `"string"`. |
-| `format`        | String         | A string specifier for formatting the field value in the tooltip. If `formatType` is `"number"`, you can provide a [number format string-specifier](https://github.com/mbostock/d3/wiki/Formatting). If `formatType` is `"time"`, you can provide a [time format string-specifier](https://github.com/mbostock/d3/wiki/Time-Formatting). If `formatType` is `"string"`, there is no need to provide a `format`. |
+| `format`        | String         | A string for formatting the field value in the tooltip. If `formatType` is `"number"`, you can provide a [d3 number format specifier](https://github.com/mbostock/d3/wiki/Formatting). If `formatType` is `"time"`, you can provide a [d3 time format specifier](https://github.com/mbostock/d3/wiki/Time-Formatting) or a [vega-lite timeUnit](https://vega.github.io/vega-lite/docs/timeunit.html). If `formatType` is `"string"`, there is no need to provide a `format`. |
 | `aggregate`     | String         | (Vega-Lite only) If your Vega-Lite visualization has multiple aggregations of the same field, you can specify the aggregation to identify the particular aggregated field. <br>__Supported values:__ [Vega-Lite aggregate operations](https://vega.github.io/vega-lite/docs/aggregate.html#supported-aggregation-operations)|

--- a/exampleSpecs/line_quarter.vl.json
+++ b/exampleSpecs/line_quarter.vl.json
@@ -1,0 +1,11 @@
+{
+  "description": "Stock price mean per quarter broken down by years.",
+  "data": {"url": "data/stocks.csv"},
+  "mark": "point",
+  "encoding": {
+    "x": {"field": "date", "type": "temporal", "timeUnit": "quarter"},
+    "y": {"field": "price", "type": "quantitative", "aggregate": "mean"},
+    "color": {"field": "symbol", "type": "nominal"},
+    "column": {"field": "date", "type": "temporal", "timeUnit": "year"}
+  }
+}

--- a/examples.js
+++ b/examples.js
@@ -136,13 +136,14 @@
     fields: [
       {
         field: "date",
-        formatType: "time",
-        format: "%Y-%m-%d"
+        formatType: "time"
       }
     ]
   }
   addVlExample("exampleSpecs/overlay_area_short.json", "#vis-overlay-area", overlayAreaOpts);
 
+  // Quarter Line Chart
+  addVlExample("exampleSpecs/line_quarter.vl.json", "#vis-quarter-line");
 
   /* Vega Examples */
   // Arc

--- a/index.html
+++ b/index.html
@@ -53,6 +53,8 @@
   <!-- Overlay Area Chart -->
   <div id="vis-overlay-area" class="tooltip-example"></div>
 
+  <!-- Quarter Line Chart -->
+  <div id="vis-quarter-line" class="tooltip-example"></div>
 
   <h1>Vega Tooltip Examples</h1>
   <!-- Arc -->


### PR DESCRIPTION
![quarter](https://cloud.githubusercontent.com/assets/822034/18046617/8ce5cfda-6d8d-11e6-9cac-400b1ffb0e61.png)

Use template for temporal fields so that we can properly show quarters in tooltip. Fix #49 
- [x] Remove hacky time template parsing code
- [x] Allow `options.format` to be a vega-lite timeUnit (as well as a d3 time format specifier or a d3 number format specifier). Figure out whether `options.format` is a timeUnit or a d3 time format specifier in `function customFormat()`, and make a template in that function. This way, both vg.tooltip and vl.tooltip use template for T fields (`customFormat()` is used by both vg.tooltip and vl.tooltip. `supplementOptions()` is only used by vl.tooltip).
- [x] Add a quarter timeUnit example
- [x] Update docs
- [x] Console warn about dropping quantitative fields on lines & areas
