### PR TITLE
Document vg.tooltip usage in vg.embed context. Fix #70

### DIFF
--- a/docs/creating_your_tooltip.md
+++ b/docs/creating_your_tooltip.md
@@ -103,7 +103,19 @@ vg.embed("#vis-scatter", embedSpec, function(error, result) {
 
 For [Vega](http://vega.github.io/vega/):
 
-You can create your tooltip using [`vg.tooltip`](APIs.md#vgtooltip). This function only requires the [`Vega View`](https://github.com/vega/vega/wiki/Runtime#view-component-api) as input.
+You can create your tooltip using [`vg.tooltip`](APIs.md#vgtooltip). This function only requires the [`Vega View`](https://github.com/vega/vega/wiki/Runtime#view-component-api) as input. For example:
+
+```js
+var embedSpec = {
+  spec: vgSpec
+}
+vg.embed(id, embedSpec, function(error, result) {
+  // result.view is the Vega View
+  vg.tooltip(result.view, options);
+});
+```
+
+As another example:
 
 ```js
 vg.parse.spec(vgSpec, function(error, chart) {

--- a/examples.js
+++ b/examples.js
@@ -26,6 +26,9 @@
         return console.error(error);
       }
       vg.parse.spec(vgSpec, function(error, chart) {
+        if (error) {
+          return console.error(error);
+        }
         var view = chart({el:id}).update();
         vg.tooltip(view, options);
       });


### PR DESCRIPTION
- Add a code example of using `vg.tooltip` in `vg.embed` context in documentation
- console log error if `vg.parse.spec` has error
