### PR TITLE
Fix bin fields cannot found and ignores the blank space scenegraph

### DIFF
--- a/exampleSpecs/bar_layered_transparent.json
+++ b/exampleSpecs/bar_layered_transparent.json
@@ -1,13 +1,8 @@
 {
   "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
   "description": "A bar chart showing the US population distribution of age groups and gender in 2000.",
-  "data": {
-    "url": "data/population.json"
-  },
+  "data": {"url": "data/population.json"},
   "transform": [
-    {
-      "filter": "datum.year == 2000"
-    },
     {
       "calculate": "datum.sex == 2 ? 'Female' : 'Male'",
       "as": "gender"
@@ -18,31 +13,20 @@
     "x": {
       "field": "age",
       "type": "ordinal",
-      "scale": {
-        "rangeStep": 17
-      }
+      "scale": {"rangeStep": 17}
     },
     "y": {
       "aggregate": "sum",
       "field": "people",
       "type": "quantitative",
-      "axis": {
-        "title": "population"
-      },
+      "axis": {"title": "population"},
       "stack": "none"
     },
     "color": {
       "field": "gender",
       "type": "nominal",
-      "scale": {
-        "range": [
-          "#e377c2",
-          "#1f77b4"
-        ]
-      }
+      "scale": {"range": ["#e377c2","#1f77b4"]}
     },
-    "opacity": {
-      "value": 0.7
-    }
+    "opacity": {"value": 0.7}
   }
 }

--- a/exampleSpecs/scatter_binned.json
+++ b/exampleSpecs/scatter_binned.json
@@ -1,21 +1,21 @@
 {
+  "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
   "data": {"url": "data/movies.json"},
-  "mark": "square",
+  "mark": "circle",
   "encoding": {
     "x": {
-      "bin": {"maxbins": 10},
-      "field": "Rotten_Tomatoes_Rating",
-      "type": "quantitative"
-    },
-    "y": {
       "bin": {"maxbins": 10},
       "field": "IMDB_Rating",
       "type": "quantitative"
     },
+    "y": {
+      "bin": {"maxbins": 10},
+      "field": "Rotten_Tomatoes_Rating",
+      "type": "quantitative"
+    },
     "size": {
       "aggregate": "count",
-      "field": "*", "type":
-      "quantitative"
+      "type": "quantitative"
     }
   }
 }

--- a/exampleSpecs/trellis_barley.json
+++ b/exampleSpecs/trellis_barley.json
@@ -1,14 +1,20 @@
 {
+  "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
   "description": "The Trellis display by Becker et al. helped establish small multiples as a “powerful mechanism for understanding interactions in studies of how a response depends on explanatory variables”. Here we reproduce a trellis of Barley yields from the 1930s, complete with main-effects ordering to facilitate comparison.",
   "data": {"url": "data/barley.json"},
   "mark": "point",
   "encoding": {
-    "row": {"field": "site", "type": "ordinal"},
-    "x": {"aggregate": "mean", "field": "yield", "type": "quantitative"},
+    "row": {
+      "field": "site", "type": "ordinal"
+    },
+    "x": {
+      "aggregate": "median", "field": "yield", "type": "quantitative",
+      "scale": {"zero": false}
+    },
     "y": {
       "field": "variety", "type": "ordinal",
-      "sort": {"field": "yield","op": "mean"},
-      "scale": {"bandSize": 12}
+      "sort": {"field": "yield","op": "median", "order": "descending"},
+      "scale": {"rangeStep": 12}
     },
     "color": {"field": "year", "type": "nominal"}
   }

--- a/index.html
+++ b/index.html
@@ -4,16 +4,16 @@
   <meta charset="utf-8">
 
   <!-- Tooltip Library -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.0.0/d3.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/vega/3.0.0-beta.28/vega.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/vega-lite/2.0.0-alpha.8/vega-lite.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/vega-embed/3.0.0-beta.0/vega-embed.js" charset="utf-8"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.0.0/d3.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/vega/3.0.0-beta.31/vega.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/vega-lite/2.0.0-beta.2/vega-lite.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/vega-embed/3.0.0-beta.14/vega-embed.min.js" charset="utf-8"></script>
 
   <script src="build/vega-tooltip.js"></script>
   <link rel="stylesheet" type="text/css" href="build/vega-tooltip.css">
 
   <!-- Example Page -->
-  <script src="examples.js"></script>
+  <script type="text/javascript" src="examples.js"></script>
   <link rel="stylesheet" type="text/css" href="examples.css">
 
 </head>

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "d3-format": "^1.2.0",
     "d3-time-format": "^2.0.5",
     "vega": "^3.0.0-beta.28",
-    "vega-lite": "^2.0.0-alpha.8"
+    "vega-lite": "^2.0.0-alpha.10"
   },
   "browserify-shim": {
     "vega": "global:vega",

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
   "dependencies": {
     "d3-format": "^1.2.0",
     "d3-time-format": "^2.0.5",
-    "vega": "^3.0.0-beta.28",
-    "vega-lite": "^2.0.0-alpha.10"
+    "vega": "^3.0.0-beta.30",
+    "vega-lite": "^2.0.0-beta.2"
   },
   "browserify-shim": {
     "vega": "global:vega",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2965,8 +2965,8 @@ tslint@~4.5.1:
     update-notifier "^2.0.0"
 
 tsutils@^1.1.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-1.8.0.tgz#bf8118ed8e80cd5c9fc7d75728c7963d44ed2f52"
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-1.9.1.tgz#b9f9ab44e55af9681831d5f28d0aeeaf5c750cb0"
 
 tty-browserify@~0.0.0:
   version "0.0.0"
@@ -3156,7 +3156,7 @@ vega-hierarchy@>=1.0.0-beta:
     vega-dataflow ">=2.0.0-beta.4"
     vega-util "1"
 
-vega-lite@^2.0.0-alpha.10, vega-lite@^2.0.0-beta.1:
+vega-lite@^2.0.0-beta.1, vega-lite@^2.0.0-beta.2:
   version "2.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/vega-lite/-/vega-lite-2.0.0-beta.2.tgz#3536bbe7ea831241fb680a52f85415bf16057f64"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,8 +35,8 @@
   resolved "https://registry.yarnpkg.com/@types/d3-dispatch/-/d3-dispatch-1.0.4.tgz#91b8de6198053efc46788ad5f27182bcc42335b5"
 
 "@types/d3-drag@*":
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/@types/d3-drag/-/d3-drag-1.0.7.tgz#233cb777770a3ac2a82b076e38b543c563381d7e"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-drag/-/d3-drag-1.1.0.tgz#9105e35ca58aa0c4783f3ce83082bcb24ccb6960"
   dependencies:
     "@types/d3-selection" "*"
 
@@ -89,8 +89,8 @@
   resolved "https://registry.yarnpkg.com/@types/d3-queue/-/d3-queue-3.0.4.tgz#a86b6d55e307d363aedd5153d8f1117793df6710"
 
 "@types/d3-random@*":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@types/d3-random/-/d3-random-1.0.5.tgz#e1d212f503376899f8a290ebae9cbf606eac856d"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-random/-/d3-random-1.1.0.tgz#2dd08f1159c70719270e4a7c834af85c8b88d2c3"
 
 "@types/d3-request@*":
   version "1.0.1"
@@ -137,8 +137,8 @@
   resolved "https://registry.yarnpkg.com/@types/d3-voronoi/-/d3-voronoi-1.1.5.tgz#67d03acb2d56006bb202c20cee1b8d5ad9fe0461"
 
 "@types/d3-zoom@*":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@types/d3-zoom/-/d3-zoom-1.1.3.tgz#4569be5f4f7bb01330e8cbc8ab93fd29b84f167e"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-zoom/-/d3-zoom-1.2.0.tgz#ccfab87d95fafa7f471f112c1cb097902b5068b5"
   dependencies:
     "@types/d3-interpolate" "*"
     "@types/d3-selection" "*"
@@ -656,7 +656,7 @@ chokidar@^1.0.0:
   optionalDependencies:
     fsevents "^1.0.0"
 
-cipher-base@^1.0.0, cipher-base@^1.0.1:
+cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.3.tgz#eeabf194419ce900da3018c207d212f2a6df0a07"
   dependencies:
@@ -785,21 +785,25 @@ create-error-class@^3.0.0:
   dependencies:
     capture-stack-trace "^1.0.0"
 
-create-hash@^1.1.0, create-hash@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.1.2.tgz#51210062d7bb7479f6c65bb41a92208b1d61abad"
+create-hash@^1.1.0, create-hash@^1.1.1, create-hash@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.1.3.tgz#606042ac8b9262750f483caddab0f5819172d8fd"
   dependencies:
     cipher-base "^1.0.1"
     inherits "^2.0.1"
-    ripemd160 "^1.0.0"
-    sha.js "^2.3.6"
+    ripemd160 "^2.0.0"
+    sha.js "^2.4.0"
 
-create-hmac@^1.1.0, create-hmac@^1.1.2:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/create-hmac/-/create-hmac-1.1.4.tgz#d3fb4ba253eb8b3f56e39ea2fbcb8af747bd3170"
+create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/create-hmac/-/create-hmac-1.1.6.tgz#acb9e221a4e17bdb076e90657c42b93e3726cf06"
   dependencies:
+    cipher-base "^1.0.3"
     create-hash "^1.1.0"
     inherits "^2.0.1"
+    ripemd160 "^2.0.0"
+    safe-buffer "^5.0.1"
+    sha.js "^2.4.8"
 
 cross-spawn-async@^2.1.1:
   version "2.2.5"
@@ -863,7 +867,7 @@ css-system-font-keywords@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/css-system-font-keywords/-/css-system-font-keywords-1.0.0.tgz#85c6f086aba4eb32c571a3086affc434b84823ed"
 
-d3-array@1, d3-array@1.2.0:
+d3-array@1, d3-array@1.2.0, d3-array@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.0.tgz#147d269720e174c4057a7f42be8b0f3f2ba53108"
 
@@ -895,6 +899,12 @@ d3-collection@1, d3-collection@1.0.3, d3-collection@^1.0.2:
 d3-color@1, d3-color@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.0.3.tgz#bc7643fca8e53a8347e2fbdaffa236796b58509b"
+
+d3-contour@1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/d3-contour/-/d3-contour-1.1.0.tgz#8290302491703c75109e9f515a1e0ce4734d42b7"
+  dependencies:
+    d3-array "^1.1.1"
 
 d3-dispatch@1, d3-dispatch@1.0.3:
   version "1.0.3"
@@ -1122,8 +1132,8 @@ decamelize@^1.0.0, decamelize@^1.1.1:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
 deep-extend@~0.4.0:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.1.tgz#efe4113d08085f4e6f9687759810f807469e2253"
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
 
 defined@^1.0.0:
   version "1.0.0"
@@ -1585,6 +1595,12 @@ has@^1.0.0:
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
   dependencies:
     function-bind "^1.0.2"
+
+hash-base@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/hash-base/-/hash-base-2.0.2.tgz#66ea1d856db4e8a5470cadf6fce23ae5244ef2e1"
+  dependencies:
+    inherits "^2.0.1"
 
 hash.js@^1.0.0, hash.js@^1.0.3:
   version "1.0.3"
@@ -2285,10 +2301,14 @@ path-type@^1.0.0:
     pinkie-promise "^2.0.0"
 
 pbkdf2@^3.0.3:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.9.tgz#f2c4b25a600058b3c3773c086c37dbbee1ffe693"
+  version "3.0.12"
+  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.12.tgz#be36785c5067ea48d806ff923288c5f750b6b8a2"
   dependencies:
-    create-hmac "^1.1.2"
+    create-hash "^1.1.2"
+    create-hmac "^1.1.4"
+    ripemd160 "^2.0.1"
+    safe-buffer "^5.0.1"
+    sha.js "^2.4.8"
 
 performance-now@^0.2.0:
   version "0.2.0"
@@ -2572,9 +2592,12 @@ rimraf@2, rimraf@^2.5.1, rimraf@^2.6.1:
   dependencies:
     glob "^7.0.5"
 
-ripemd160@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-1.0.1.tgz#93a4bbd4942bc574b69a8fa57c71de10ecca7d6e"
+ripemd160@^2.0.0, ripemd160@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.1.tgz#0f4584295c53a3628af7e6d79aca21ce57d1c6e7"
+  dependencies:
+    hash-base "^2.0.0"
+    inherits "^2.0.1"
 
 rw@1:
   version "1.3.3"
@@ -2602,7 +2625,7 @@ set-immediate-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
 
-sha.js@^2.3.6, sha.js@~2.4.4:
+sha.js@^2.4.0, sha.js@^2.4.8, sha.js@~2.4.4:
   version "2.4.8"
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.8.tgz#37068c2c476b6baf402d14a49c67f597921f634f"
   dependencies:
@@ -2968,8 +2991,8 @@ typescript@^2.2.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.3.2.tgz#f0f045e196f69a72f06b25fd3bd39d01c3ce9984"
 
 uglify-js@^2.6.2:
-  version "2.8.23"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.23.tgz#8230dd9783371232d62a7821e2cf9a817270a8a0"
+  version "2.8.24"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.24.tgz#48eb5175cf32e22ec11a47e638d7c8b4e0faf2dd"
   dependencies:
     source-map "~0.5.1"
     yargs "~3.10.0"
@@ -3116,9 +3139,10 @@ vega-force@>=1.0.0-beta:
     vega-util "1"
 
 vega-geo@>=1.0.0-beta:
-  version "1.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/vega-geo/-/vega-geo-1.0.0-beta.2.tgz#9c5d7d1b5177ba55d061e3877edc3c9858eacc0b"
+  version "1.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/vega-geo/-/vega-geo-1.0.0-beta.3.tgz#6cd66e421eb7240d7e6c50367b05d0d358cae064"
   dependencies:
+    d3-contour "1"
     d3-geo "1"
     vega-dataflow ">=2.0.0-beta.4"
     vega-util "1"
@@ -3132,7 +3156,7 @@ vega-hierarchy@>=1.0.0-beta:
     vega-dataflow ">=2.0.0-beta.4"
     vega-util "1"
 
-vega-lite@^2.0.0-alpha.8, vega-lite@^2.0.0-beta.1:
+vega-lite@^2.0.0-alpha.10, vega-lite@^2.0.0-beta.1:
   version "2.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/vega-lite/-/vega-lite-2.0.0-beta.2.tgz#3536bbe7ea831241fb680a52f85415bf16057f64"
   dependencies:
@@ -3153,8 +3177,8 @@ vega-loader@>=2.0.0-beta, vega-loader@>=2.0.0-beta.5:
     vega-util "1"
 
 vega-parser@>=1.0.0-beta:
-  version "1.0.0-beta.51"
-  resolved "https://registry.yarnpkg.com/vega-parser/-/vega-parser-1.0.0-beta.51.tgz#325435c79159e6b88ab4e555b758319eb12b5183"
+  version "1.0.0-beta.52"
+  resolved "https://registry.yarnpkg.com/vega-parser/-/vega-parser-1.0.0-beta.52.tgz#095a3cdf7477593c35c8f5fe0a067a2aa7ae5d3a"
   dependencies:
     d3-array "1"
     d3-color "1"
@@ -3239,8 +3263,8 @@ vega-wordcloud@>=1.0.0-beta:
     canvas "^1.6.0"
 
 vega@^3.0.0-beta.28, vega@^3.0.0-beta.30:
-  version "3.0.0-beta.30"
-  resolved "https://registry.yarnpkg.com/vega/-/vega-3.0.0-beta.30.tgz#3d471cf801b1cc3b3f53a9efb9baeea0a26f7e94"
+  version "3.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/vega/-/vega-3.0.0-beta.31.tgz#e92e4fe9d8caf9bf6d4647ecc9f7ae9b0c31395a"
   dependencies:
     vega-crossfilter ">=1.0.0-beta"
     vega-dataflow ">=2.0.0-beta"
@@ -3300,10 +3324,10 @@ which@^1.2.8:
     isexe "^2.0.0"
 
 wide-align@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.1.tgz#d2ea8aa2db2e66467e8b60cc3e897de3bc4429e6"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.2.tgz#571e0f1b0604636ebc0dfc21b0339bbe31341710"
   dependencies:
-    string-width "^2.0.0"
+    string-width "^1.0.2"
 
 widest-line@^1.0.0:
   version "1.0.0"
@@ -3339,8 +3363,8 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
 
 write-file-atomic@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.0.0.tgz#bb99a5440d0d31dd860a68da392bffeef66251a1"
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.1.0.tgz#1769f4b551eedce419f0505deae2e26763542d37"
   dependencies:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"


### PR DESCRIPTION
- fix the cannot find field error with bin fields due to vega API change
- ignores the display for the `nested-main-group` scenegraph, which represents the blank tiles