### PR TITLE
split file into modules and combine all typing declaration

### DIFF
--- a/examples.css
+++ b/examples.css
@@ -1,10 +1,6 @@
 body {
   font-family: sans-serif;
 }
-h1 {
-  text-align: center;
-  margin: 100px 0px 25px;
-}
 
 /* Hide Vega action links */
 .vega-actions {
@@ -18,4 +14,16 @@ h1 {
 .tooltip-example canvas {
   display: block;
   margin: auto;
+}
+
+.large {
+  margin: 50px 0px 25px;
+  font-size: 1.5em;
+}
+
+.center {
+  text-align: center;
+}
+.center a {
+  display: block;
 }

--- a/examples.js
+++ b/examples.js
@@ -93,7 +93,6 @@
     fields: [
       {field: "Rotten_Tomatoes_Rating"},
       {field: "IMDB_Rating"},
-      {field: "*"}
     ]
   };
   addVlExample("exampleSpecs/scatter_binned.json", "#vis-scatter-binned", binMovieOpts);

--- a/index.html
+++ b/index.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html>
 
 <head>
   <title>Tooltip Examples</title>
@@ -8,8 +9,8 @@
 </head>
 
 <body>
-    <h1><a href="vega-examples.html">Vega Tooltip Examples</a></h1>
-    <h1><a href="vega-lite-examples.html">Vega-Lite Tooltip Examples</a></h1>
+  <h1><a href="vega-examples.html">Vega Tooltip Examples</a></h1>
+  <h1><a href="vega-lite-examples.html">Vega-Lite Tooltip Examples</a></h1>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -8,9 +8,9 @@
 
 </head>
 
-<body>
-  <h1><a href="vega-examples.html">Vega Tooltip Examples</a></h1>
-  <h1><a href="vega-lite-examples.html">Vega-Lite Tooltip Examples</a></h1>
+<body class="center">
+  <a href="vega-examples.html" class="large">Vega Tooltip Examples</a>
+  <a href="vega-lite-examples.html" class="large">Vega-Lite Tooltip Examples</a>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -1,78 +1,15 @@
 <!DOCTYPE html>
+
 <head>
   <title>Tooltip Examples</title>
   <meta charset="utf-8">
-
-  <!-- Tooltip Library -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/vega/3.0.0-beta.31/vega.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/vega-lite/2.0.0-beta.2/vega-lite.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/vega-embed/3.0.0-beta.14/vega-embed.min.js" charset="utf-8"></script>
-  <script src="https://d3js.org/d3-format.v1.min.js"></script>
-  <script src="https://d3js.org/d3-time.v1.min.js"></script>
-  <script src="https://d3js.org/d3-time-format.v2.min.js"></script>
-  <script src="https://d3js.org/d3-collection.v1.min.js"></script>
-  <script src="https://d3js.org/d3-dispatch.v1.min.js"></script>
-  <script src="https://d3js.org/d3-dsv.v1.min.js"></script>
-  <script src="https://d3js.org/d3-request.v1.min.js"></script>
-
-  <script src="build/vega-tooltip.js"></script>
-  <link rel="stylesheet" type="text/css" href="build/vega-tooltip.css">
-
-  <!-- Example Page -->
-  <script type="text/javascript" src="examples.js"></script>
   <link rel="stylesheet" type="text/css" href="examples.css">
 
 </head>
 
 <body>
-  <h1>Vega-Lite Tooltip Examples</h1>
-
-  <!-- Scatter Plot -->
-  <div id="vis-scatter" class="tooltip-example"></div>
-
-  <!-- Bubble Plot -->
-  <div id="vis-bubble-multi-aggr" class="tooltip-example"></div>
-
-  <!-- Trellis Barley -->
-  <div id="vis-trellis-barley" class="tooltip-example"></div>
-
-  <!-- Scatter Binned -->
-  <div id="vis-scatter-binned" class="tooltip-example"></div>
-
-  <!-- Simple Bar Chart -->
-  <div id="vis-bar" class="tooltip-example"></div>
-
-  <!-- Stacked Bar Chart -->
-  <div id="vis-stacked-bar" class="tooltip-example"></div>
-
-  <!-- Layered Bar Chart -->
-  <div id="vis-layered-bar" class="tooltip-example"></div>
-
-  <!-- Color Line Chart -->
-  <div id="vis-color-line" class="tooltip-example"></div>
-
-  <!-- Overlay Line Chart -->
-  <div id="vis-overlay-line" class="tooltip-example"></div>
-
-  <!-- Overlay Area Chart -->
-  <div id="vis-overlay-area" class="tooltip-example"></div>
-
-
-  <h1>Vega Tooltip Examples</h1>
-  <!-- Arc -->
-  <div id="vis-arc" class="tooltip-example"></div>
-
-  <!-- Choropleth -->
-  <div id="vis-choropleth" class="tooltip-example"></div>
-
-  <!-- Force -->
-  <div id="vis-force" class="tooltip-example"></div>
-
-  <!-- Heatmap -->
-  <div id="vis-heatmap" class="tooltip-example"></div>
-
-  <!-- Placeholder for Tooltip -->
-  <div id="vis-tooltip" class="vg-tooltip"></div>
-
+    <h1><a href="vega-examples.html">Vega Tooltip Examples</a></h1>
+    <h1><a href="vega-lite-examples.html">Vega-Lite Tooltip Examples</a></h1>
 </body>
+
 </html>

--- a/index.html
+++ b/index.html
@@ -4,10 +4,16 @@
   <meta charset="utf-8">
 
   <!-- Tooltip Library -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.0.0/d3.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vega/3.0.0-beta.31/vega.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vega-lite/2.0.0-beta.2/vega-lite.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vega-embed/3.0.0-beta.14/vega-embed.min.js" charset="utf-8"></script>
+  <script src="https://d3js.org/d3-format.v1.min.js"></script>
+  <script src="https://d3js.org/d3-time.v1.min.js"></script>
+  <script src="https://d3js.org/d3-time-format.v2.min.js"></script>
+  <script src="https://d3js.org/d3-collection.v1.min.js"></script>
+  <script src="https://d3js.org/d3-dispatch.v1.min.js"></script>
+  <script src="https://d3js.org/d3-dsv.v1.min.js"></script>
+  <script src="https://d3js.org/d3-request.v1.min.js"></script>
 
   <script src="build/vega-tooltip.js"></script>
   <link rel="stylesheet" type="text/css" href="build/vega-tooltip.css">

--- a/src/formatFieldValue.ts
+++ b/src/formatFieldValue.ts
@@ -3,14 +3,14 @@ import {timeDay, timeHour, timeMinute, timeMonth, timeSecond, timeWeek, timeYear
 import {timeFormat} from 'd3-time-format';
 
 /**
-* Format value using formatType and format
-* @param value - a field value to be formatted
-* @param formatType - the formatType can be: "time", "number", or "string"
-* @param format - a time time format specifier, or a time number format specifier, or undefined
-* @return the formatted value, or undefined if value or formatType is missing
-*/
+ * Format value using formatType and format
+ * @param value - a field value to be formatted
+ * @param formatType - the formatType can be: "time", "number", or "string"
+ * @param format - a time time format specifier, or a time number format specifier, or undefined
+ * @return the formatted value, or undefined if value or formatType is missing
+ */
 export function customFormat(value: number | string | Date, formatType: string, format: string): string {
-  if (value === undefined || value === null)  {
+  if (value === undefined || value === null) {
     return undefined;
   }
   if (!formatType) {
@@ -29,9 +29,9 @@ export function customFormat(value: number | string | Date, formatType: string, 
 }
 
 /**
-* Automatically format a time, number or string value
-* @return the formatted time, number or string value
-*/
+ * Automatically format a time, number or string value
+ * @return the formatted time, number or string value
+ */
 export function autoFormat(value: string | number | Date): string {
   if (typeof value === 'number') {
     return autoNumberFormat(value);
@@ -69,10 +69,10 @@ export function autoTimeFormat(date: Date) {
     formatYear = timeFormat('%Y');
 
   return (timeSecond(date) < date ? formatMillisecond
-      : timeMinute(date) < date ? formatSecond
+    : timeMinute(date) < date ? formatSecond
       : timeHour(date) < date ? formatMinute
-      : timeDay(date) < date ? formatHour
-      : timeMonth(date) < date ? (timeWeek(date) < date ? formatDay : formatWeek)
-      : timeYear(date) < date ? formatMonth
-      : formatYear)(date);
+        : timeDay(date) < date ? formatHour
+          : timeMonth(date) < date ? (timeWeek(date) < date ? formatDay : formatWeek)
+            : timeYear(date) < date ? formatMonth
+              : formatYear)(date);
 }

--- a/src/formatFieldValue.ts
+++ b/src/formatFieldValue.ts
@@ -1,0 +1,78 @@
+import {format as d3NumberFormat} from 'd3-format';
+import {timeDay, timeHour, timeMinute, timeMonth, timeSecond, timeWeek, timeYear} from 'd3-time';
+import {timeFormat} from 'd3-time-format';
+
+/**
+* Format value using formatType and format
+* @param value - a field value to be formatted
+* @param formatType - the formatType can be: "time", "number", or "string"
+* @param format - a time time format specifier, or a time number format specifier, or undefined
+* @return the formatted value, or undefined if value or formatType is missing
+*/
+export function customFormat(value: number | string | Date, formatType: string, format: string): string {
+  if (value === undefined || value === null)  {
+    return undefined;
+  }
+  if (!formatType) {
+    return undefined;
+  }
+
+  switch (formatType) {
+    case 'time':
+      return format ? timeFormat(format)(value as Date) : autoTimeFormat(value as Date);
+    case 'number':
+      return format ? d3NumberFormat(format)(value as number) : autoNumberFormat(value as number);
+    case 'string':
+    default:
+      return value as string;
+  }
+}
+
+/**
+* Automatically format a time, number or string value
+* @return the formatted time, number or string value
+*/
+export function autoFormat(value: string | number | Date): string {
+  if (typeof value === 'number') {
+    return autoNumberFormat(value);
+  } else if (value instanceof Date) {
+    return autoTimeFormat(value);
+  } else {
+    return value;
+  }
+}
+
+/**
+ * Automatically format a number based on its decimal.
+ * @param value number to be formatted
+ * @return If it's a decimal number, return a fixed two points precision.
+ * If it's a whole number, return the original value without any format.
+ */
+export function autoNumberFormat(value: number) {
+  return value % 1 === 0 ? d3NumberFormat(',')(value) : d3NumberFormat(',.2f')(value);
+}
+
+/**
+ * Automatically format a time based on its date.
+ * @param date object to be formatted
+ * @return a formatted time string depending on the time. For example,
+ * the start of February is formatted as "February", while February second is formatted as "Feb 2".
+ */
+export function autoTimeFormat(date: Date) {
+  const formatMillisecond = timeFormat('.%L'),
+    formatSecond = timeFormat(':%S'),
+    formatMinute = timeFormat('%I:%M'),
+    formatHour = timeFormat('%I %p'),
+    formatDay = timeFormat('%a %d'),
+    formatWeek = timeFormat('%b %d'),
+    formatMonth = timeFormat('%B'),
+    formatYear = timeFormat('%Y');
+
+  return (timeSecond(date) < date ? formatMillisecond
+      : timeMinute(date) < date ? formatSecond
+      : timeHour(date) < date ? formatMinute
+      : timeDay(date) < date ? formatHour
+      : timeMonth(date) < date ? (timeWeek(date) < date ? formatDay : formatWeek)
+      : timeYear(date) < date ? formatMonth
+      : formatYear)(date);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,23 +5,21 @@ import {getTooltipData} from './parseOption';
 import {supplementOptions} from './supplementField';
 import {bindData, clearColorTheme, clearData, clearPosition, getTooltipPlaceholder, updateColorTheme, updatePosition} from './tooltipDisplay';
 
-let tooltipPromise: number;
-tooltipPromise = undefined;
+let tooltipPromise: number = undefined;
 
-let tooltipActive: boolean;
-tooltipActive = false;
+let tooltipActive = false;
 
 /**
-* Export API for Vega visualizations: vg.tooltip(vgView, options)
-* options can specify whether to show all fields or to show only custom fields
-* It can also provide custom title and format for fields
-*/
+ * Export API for Vega visualizations: vg.tooltip(vgView, options)
+ * options can specify whether to show all fields or to show only custom fields
+ * It can also provide custom title and format for fields
+ */
 export function vega(vgView: VgView, options: Option = {showAllFields: true}) {
   // initialize tooltip with item data and options on mouse over
   vgView.addEventListener('mouseover.tooltipInit', function (event: MouseEvent, item: Scenegraph) {
     if (shouldShowTooltip(item)) {
       // clear existing promise because mouse can only point at one thing at a time
-      cancelPromise(tooltipPromise);
+      cancelPromise();
 
       tooltipPromise = window.setTimeout(function () {
         init(event, item, options);
@@ -40,7 +38,7 @@ export function vega(vgView: VgView, options: Option = {showAllFields: true}) {
   // clear tooltip on mouse out
   vgView.addEventListener('mouseout.tooltipRemove', function (event: MouseEvent, item: Scenegraph) {
     if (shouldShowTooltip(item)) {
-      cancelPromise(tooltipPromise);
+      cancelPromise();
 
       if (tooltipActive) {
         clear(event, item, options);
@@ -55,7 +53,7 @@ export function vega(vgView: VgView, options: Option = {showAllFields: true}) {
       vgView.removeEventListener('mousemove.tooltipUpdate');
       vgView.removeEventListener('mouseout.tooltipRemove');
 
-      cancelPromise(tooltipPromise); // clear tooltip promise
+      cancelPromise(); // clear tooltip promise
     }
   };
 };
@@ -68,7 +66,7 @@ export function vegaLite(vgView: VgView, vlSpec: TopLevelExtendedSpec, options: 
   vgView.addEventListener('mouseover.tooltipInit', function (event: MouseEvent, item: Scenegraph) {
     if (shouldShowTooltip(item)) {
       // clear existing promise because mouse can only point at one thing at a time
-      cancelPromise(tooltipPromise);
+      cancelPromise();
 
       // make a new promise with time delay for tooltip
       tooltipPromise = window.setTimeout(function () {
@@ -88,7 +86,7 @@ export function vegaLite(vgView: VgView, vlSpec: TopLevelExtendedSpec, options: 
   // clear tooltip on mouse out
   vgView.addEventListener('mouseout.tooltipRemove', function (event: MouseEvent, item: Scenegraph) {
     if (shouldShowTooltip(item)) {
-      cancelPromise(tooltipPromise);
+      cancelPromise();
 
       if (tooltipActive) {
         clear(event, item, options);
@@ -103,13 +101,13 @@ export function vegaLite(vgView: VgView, vlSpec: TopLevelExtendedSpec, options: 
       vgView.removeEventListener('mousemove.tooltipUpdate');
       vgView.removeEventListener('mouseout.tooltipRemove');
 
-      cancelPromise(tooltipPromise); // clear tooltip promise
+      cancelPromise(); // clear tooltip promise
     }
   };
 };
 
 /* Cancel tooltip promise */
-function cancelPromise(tooltipPromise) {
+function cancelPromise() {
   /* We don't check if tooltipPromise is valid because passing
    an invalid ID to clearTimeout does not have any effect
    (and doesn't throw an exception). */
@@ -174,7 +172,7 @@ function clear(event: MouseEvent, item: Scenegraph, options: Option) {
 /* Decide if a Scenegraph item deserves tooltip */
 function shouldShowTooltip(item: Scenegraph) {
   // no data, no show
-  if (!item || !item.datum)  {
+  if (!item || !item.datum) {
     return false;
   }
   // (small multiples) avoid showing tooltip for a facet's background

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,33 +1,15 @@
-import {Map, map as d3map} from 'd3-collection';
-import {format as d3NumberFormat} from 'd3-format';
-import {EnterElement, select, Selection} from 'd3-selection';
-import {timeDay, timeHour, timeMinute, timeMonth, timeSecond, timeWeek, timeYear} from 'd3-time';
-import {timeFormat} from 'd3-time-format';
-import {FieldDef} from 'vega-lite/build/src/fielddef';
+import {select} from 'd3-selection';
 import {TopLevelExtendedSpec} from 'vega-lite/build/src/spec';
-import {TEMPORAL} from 'vega-lite/build/src/type';
-import * as vl from 'vega-lite/build/src/vl';
-import {FieldOption, Option} from './options';
-import {SupplementedFieldOption} from './supplementedFieldOption';
+import {DELAY, Option, Scenegraph, VgView} from './options';
+import {getTooltipData} from './parseOption';
+import {supplementOptions} from './supplementField';
+import {bindData, clearColorTheme, clearData, clearPosition, getTooltipPlaceholder, updateColorTheme, updatePosition} from './tooltipDisplay';
 
-// by default, delay showing tooltip for 100 ms
-const DELAY = 100;
-let tooltipPromise: number = undefined;
-let tooltipActive = false;
+let tooltipPromise: number;
+tooltipPromise = undefined;
 
-export type VgView = any;
-type SceneGraph = {
-  datum: {
-    _facetID: number,
-    _id: number
-  },
-  mark: {
-    marktype: string,
-    items: object,
-    name: string
-  }
-};
-type ToolTipData = {title: string, value: string | number };
+let tooltipActive: boolean;
+tooltipActive = false;
 
 /**
 * Export API for Vega visualizations: vg.tooltip(vgView, options)
@@ -35,13 +17,11 @@ type ToolTipData = {title: string, value: string | number };
 * It can also provide custom title and format for fields
 */
 export function vega(vgView: VgView, options: Option = {showAllFields: true}) {
-  // TODO: change item type to vega scenegraph
-
   // initialize tooltip with item data and options on mouse over
-  vgView.addEventListener('mouseover.tooltipInit', function (event: MouseEvent, item: SceneGraph) {
+  vgView.addEventListener('mouseover.tooltipInit', function (event: MouseEvent, item: Scenegraph) {
     if (shouldShowTooltip(item)) {
       // clear existing promise because mouse can only point at one thing at a time
-      cancelPromise();
+      cancelPromise(tooltipPromise);
 
       tooltipPromise = window.setTimeout(function () {
         init(event, item, options);
@@ -51,16 +31,16 @@ export function vega(vgView: VgView, options: Option = {showAllFields: true}) {
 
   // update tooltip position on mouse move
   // (important for large marks e.g. bars)
-  vgView.addEventListener('mousemove.tooltipUpdate', function (event: MouseEvent, item: SceneGraph) {
+  vgView.addEventListener('mousemove.tooltipUpdate', function (event: MouseEvent, item: Scenegraph) {
     if (shouldShowTooltip(item) && tooltipActive) {
       update(event, item, options);
     }
   });
 
   // clear tooltip on mouse out
-  vgView.addEventListener('mouseout.tooltipRemove', function (event: MouseEvent, item: SceneGraph) {
+  vgView.addEventListener('mouseout.tooltipRemove', function (event: MouseEvent, item: Scenegraph) {
     if (shouldShowTooltip(item)) {
-      cancelPromise();
+      cancelPromise(tooltipPromise);
 
       if (tooltipActive) {
         clear(event, item, options);
@@ -75,27 +55,20 @@ export function vega(vgView: VgView, options: Option = {showAllFields: true}) {
       vgView.removeEventListener('mousemove.tooltipUpdate');
       vgView.removeEventListener('mouseout.tooltipRemove');
 
-      cancelPromise(); // clear tooltip promise
+      cancelPromise(tooltipPromise); // clear tooltip promise
     }
   };
 };
 
-/**
-* Export API for Vega-Lite visualizations: vl.tooltip(vgView, vlSpec, options)
-* options can specify whether to show all fields or to show only custom fields
-* It can also provide custom title and format for fields
-* options can be supplemented by vlSpec
-*/
 export function vegaLite(vgView: VgView, vlSpec: TopLevelExtendedSpec, options: Option = {}) {
-
   options = supplementOptions(options, vlSpec);
 
   // TODO: update this to use new vega-view api (addEventListener)
   // initialize tooltip with item data and options on mouse over
-  vgView.addEventListener('mouseover.tooltipInit', function (event: MouseEvent, item: SceneGraph) {
+  vgView.addEventListener('mouseover.tooltipInit', function (event: MouseEvent, item: Scenegraph) {
     if (shouldShowTooltip(item)) {
       // clear existing promise because mouse can only point at one thing at a time
-      cancelPromise();
+      cancelPromise(tooltipPromise);
 
       // make a new promise with time delay for tooltip
       tooltipPromise = window.setTimeout(function () {
@@ -106,16 +79,16 @@ export function vegaLite(vgView: VgView, vlSpec: TopLevelExtendedSpec, options: 
 
   // update tooltip position on mouse move
   // (important for large marks e.g. bars)
-  vgView.addEventListener('mousemove.tooltipUpdate', function (event: MouseEvent, item: SceneGraph) {
+  vgView.addEventListener('mousemove.tooltipUpdate', function (event: MouseEvent, item: Scenegraph) {
     if (shouldShowTooltip(item) && tooltipActive) {
       update(event, item, options);
     }
   });
 
   // clear tooltip on mouse out
-  vgView.addEventListener('mouseout.tooltipRemove', function (event: MouseEvent, item: SceneGraph) {
+  vgView.addEventListener('mouseout.tooltipRemove', function (event: MouseEvent, item: Scenegraph) {
     if (shouldShowTooltip(item)) {
-      cancelPromise();
+      cancelPromise(tooltipPromise);
 
       if (tooltipActive) {
         clear(event, item, options);
@@ -130,253 +103,24 @@ export function vegaLite(vgView: VgView, vlSpec: TopLevelExtendedSpec, options: 
       vgView.removeEventListener('mousemove.tooltipUpdate');
       vgView.removeEventListener('mouseout.tooltipRemove');
 
-      cancelPromise(); // clear tooltip promise
+      cancelPromise(tooltipPromise); // clear tooltip promise
     }
   };
 };
 
 /* Cancel tooltip promise */
-function cancelPromise() {
+function cancelPromise(tooltipPromise) {
   /* We don't check if tooltipPromise is valid because passing
    an invalid ID to clearTimeout does not have any effect
    (and doesn't throw an exception). */
-  window.clearTimeout(tooltipPromise);
-  tooltipPromise = undefined;
-}
-
-/* mapping from fieldDef.type to formatType */
-const formatTypeMap: {[type: string]: 'number' | 'time'} = {
-  'quantitative': 'number',
-  'temporal': 'time',
-  'ordinal': undefined,
-  'nominal': undefined
-};
-
-/**
-* (Vega-Lite only) Supplement options with vlSpec
-*
-* @param options - user-provided options
-* @param vlSpec - vega-lite spec
-* @return the vlSpec-supplemented options object
-*
-* if options.showAllFields is true or undefined, vlSpec will supplement
-* options.fields with all fields in the spec
-* if options.showAllFields is false, vlSpec will only supplement existing fields
-* in options.fields
-*/
-function supplementOptions(options: Option, vlSpec: TopLevelExtendedSpec) {
-  // fields to be supplemented by vlSpec
-  const supplementedFields: FieldOption[] = [];
-
-  // if showAllFields is true or undefined, supplement all fields in vlSpec
-  if (options.showAllFields !== false) {
-    vl.spec.fieldDefs(vlSpec).forEach(function (fieldDef: FieldDef<string>) {
-      // get a fieldOption in options that matches the fieldDef
-      const fieldOption = getFieldOption(options.fields, fieldDef);
-
-      // supplement the fieldOption with fieldDef and config
-      const supplementedFieldOption = supplementFieldOption(fieldOption, fieldDef, vlSpec);
-
-      supplementedFields.push(supplementedFieldOption);
-    });
-  } else { // if showAllFields is false, only supplement existing fields in options.fields
-    if (options.fields) {
-      options.fields.forEach(function (fieldOption: FieldOption) {
-        // get the fieldDef in vlSpec that matches the fieldOption
-        const fieldDef = getFieldDef(vl.spec.fieldDefs(vlSpec) as FieldDef<string>[], fieldOption);
-
-        // supplement the fieldOption with fieldDef and config
-        const supplementedFieldOption = supplementFieldOption(fieldOption, fieldDef, vlSpec);
-
-        supplementedFields.push(supplementedFieldOption);
-      });
-    }
-  }
-
-  options.fields = supplementedFields;
-
-  return options;
-}
-
-/**
-* Find a fieldOption in fieldOptions that matches a fieldDef
-*
-* @param {Object[]} fieldOptionss - a list of field options (i.e. options.fields[])
-* @param {Object} fieldDef - from vlSpec
-* @return the matching fieldOption, or undefined if no match was found
-*
-* If the fieldDef is aggregated, find a fieldOption that matches the field name and
-* the aggregation of the fieldDef.
-* If the fieldDef is not aggregated, find a fieldOption that matches the field name.
-*/
-function getFieldOption(fieldOptions: FieldOption[], fieldDef: FieldDef<string>) {
-  if (!fieldDef || !fieldOptions || fieldOptions.length <= 0) {
-    return undefined;
-  }
-
-  // if aggregate, match field name and aggregate operation
-  if (fieldDef.aggregate) {
-    // try find the perfect match: field name equals, aggregate operation equals
-    for (let item of fieldOptions) {
-      if (item.field === fieldDef.field && item.aggregate === fieldDef.aggregate) {
-        return item;
-      }
-    }
-
-    // try find the second-best match: field name equals, field.aggregate is not specified
-    for (let item of fieldOptions) {
-      if (item.field === fieldDef.field && !item.aggregate) {
-        return item;
-      }
-    }
-
-    // return undefined if no match was found
-    return undefined;
-  } else { // if not aggregate, just match field name
-    for (let item of fieldOptions) {
-      if (item.field === fieldDef.field) {
-        return item;
-      }
-    }
-
-    // return undefined if no match was found
-    return undefined;
+  if (tooltipPromise) {
+    window.clearTimeout(tooltipPromise);
+    tooltipPromise = undefined;
   }
 }
-
-/**
-* Find a fieldDef that matches a fieldOption
-*
-* @param {Object} fieldOption - a field option (a member in options.fields[])
-* @return the matching fieldDef, or undefined if no match was found
-*
-* A matching fieldDef should have the same field name as fieldOption.
-* If the matching fieldDef is aggregated, the aggregation should not contradict
-* with that of the fieldOption.
-*/
-function getFieldDef(fieldDefs: FieldDef<string>[], fieldOption: FieldOption): FieldDef<string> {
-  if (!fieldOption || !fieldOption.field || !fieldDefs) {
-    return undefined;
-  }
-
-  // field name should match, aggregation should not disagree
-  for (let item of fieldDefs) {
-    if (item.field === fieldOption.field) {
-      if (item.aggregate) {
-        if (item.aggregate === fieldOption.aggregate || !fieldOption.aggregate) {
-          return item;
-        }
-      } else {
-        return item;
-      }
-    }
-  }
-
-  // return undefined if no match was found
-  return undefined;
-}
-
-/**
-* Supplement a fieldOption (from options.fields[]) with a fieldDef, config
-* (which provides timeFormat, numberFormat, countTitle)
-* Either fieldOption or fieldDef can be undefined, but they cannot both be undefined.
-* config (and its members timeFormat, numberFormat and countTitle) can be undefined.
-* @return the supplemented fieldOption, or undefined on error
-*/
-function supplementFieldOption(fieldOption: FieldOption, fieldDef: FieldDef<string>, vlSpec: TopLevelExtendedSpec) {
-  // many specs don't have config
-  const config = vl.util.extend({}, vlSpec.config);
-
-  // at least one of fieldOption and fieldDef should exist
-  if (!fieldOption && !fieldDef) {
-    console.error('[Tooltip] Cannot supplement a field when field and fieldDef are both empty.');
-    return undefined;
-  }
-
-  // if either one of fieldOption and fieldDef is undefined, make it an empty object
-  if (!fieldOption && fieldDef) {
-    fieldOption = {};
-  }
-  if (fieldOption && !fieldDef) {
-    fieldDef = {};
-  }
-
-  // the supplemented field option
-  const supplementedFieldOption: SupplementedFieldOption = {};
-
-  // supplement a user-provided field name with underscore prefixes and suffixes to
-  // match the field names in item.datum
-  // for aggregation, this will add prefix "mean_" etc.
-  // for timeUnit, this will add prefix "yearmonth_" etc.
-  // for bin, this will add prefix "bin_" and suffix "_start". Later we will replace "_start" with "_range".
-  supplementedFieldOption.field = fieldDef.field ?
-    vl.fieldDef.field(fieldDef) : fieldOption.field;
-
-  // If a fieldDef is a (TIMEUNIT)T, we check if the original T is present in the vlSpec.
-  // If only (TIMEUNIT)T is present in vlSpec, we set `removeOriginalTemporalField` to T,
-  // which will cause function removeDuplicateTimeFields() to remove T and only keep (TIMEUNIT)T
-  // in item data.
-  // If both (TIMEUNIT)T and T are in vlSpec, we set `removeOriginalTemporalField` to undefined,
-  // which will leave both T and (TIMEUNIT)T in item data.
-  // Note: user should never have to provide this boolean in options
-  if (fieldDef.type === TEMPORAL && fieldDef.timeUnit) {
-    // in most cases, if it's a (TIMEUNIT)T, we remove original T
-    const originalTemporalField = fieldDef.field;
-    supplementedFieldOption.removeOriginalTemporalField = originalTemporalField;
-
-    // handle corner case: if T is present in vlSpec, then we keep both T and (TIMEUNIT)T
-    const fieldDefs = vl.spec.fieldDefs(vlSpec);
-    for (let items of fieldDefs) {
-      if (items.field === originalTemporalField && !items.timeUnit) {
-        supplementedFieldOption.removeOriginalTemporalField = undefined;
-        break;
-      }
-    }
-  }
-
-  // supplement title
-  if (!config.countTitle) {
-    config.countTitle = vl.config.defaultConfig.countTitle; // use vl default countTitle
-  }
-  supplementedFieldOption.title = fieldOption.title ?
-    fieldOption.title : vl.fieldDef.title(fieldDef, config);
-
-  // supplement formatType
-  supplementedFieldOption.formatType = fieldOption.formatType ?
-    fieldOption.formatType : formatTypeMap[fieldDef.type];
-
-  // supplement format
-  if (fieldOption.format) {
-    supplementedFieldOption.format = fieldOption.format;
-  } else { // when user doesn't provide format, supplement format using timeUnit, timeFormat, and numberFormat
-    switch (supplementedFieldOption.formatType) {
-      case 'time':
-        supplementedFieldOption.format = fieldDef.timeUnit ?
-          // TODO(zening): use template for all time fields, to be consistent with Vega-Lite
-          vl.timeUnit.formatExpression(fieldDef.timeUnit, '', false).split("'")[1]
-          : config.timeFormat || vl.config.defaultConfig.timeFormat;
-        break;
-      case 'number':
-        supplementedFieldOption.format = config.numberFormat;
-        break;
-      case 'string':
-      default:
-    }
-  }
-
-  // supplement bin from fieldDef, user should never have to provide bin in options
-  if (fieldDef.bin) {
-    supplementedFieldOption.field = supplementedFieldOption.field.replace('_start', '_range'); // replace suffix
-    supplementedFieldOption.bin = true;
-    supplementedFieldOption.formatType = 'string'; // we show bin range as string (e.g. "5-10")
-  }
-
-  return supplementedFieldOption;
-}
-
 
 /* Initialize tooltip with data */
-function init(event: MouseEvent, item: SceneGraph, options: Option) {
+function init(event: MouseEvent, item: Scenegraph, options: Option) {
   // get tooltip HTML placeholder
   const tooltipPlaceholder = getTooltipPlaceholder();
 
@@ -401,7 +145,7 @@ function init(event: MouseEvent, item: SceneGraph, options: Option) {
 }
 
 /* Update tooltip position on mousemove */
-function update(event: MouseEvent, item: SceneGraph, options: Option) {
+function update(event: MouseEvent, item: Scenegraph, options: Option) {
   updatePosition(event, options);
 
   // invoke user-provided callback
@@ -411,7 +155,7 @@ function update(event: MouseEvent, item: SceneGraph, options: Option) {
 }
 
 /* Clear tooltip */
-function clear(event: MouseEvent, item: SceneGraph, options: Option) {
+function clear(event: MouseEvent, item: Scenegraph, options: Option) {
   // visibility hidden instead of display none
   // because we need computed tooltip width and height to best position it
   select('#vis-tooltip').style('visibility', 'hidden');
@@ -427,9 +171,8 @@ function clear(event: MouseEvent, item: SceneGraph, options: Option) {
   }
 }
 
-
-/* Decide if a scenegraph item deserves tooltip */
-function shouldShowTooltip(item: SceneGraph) {
+/* Decide if a Scenegraph item deserves tooltip */
+function shouldShowTooltip(item: Scenegraph) {
   // no data, no show
   if (!item || !item.datum)  {
     return false;
@@ -443,435 +186,4 @@ function shouldShowTooltip(item: SceneGraph) {
     return false;
   }
   return true;
-}
-
-/**
-* Prepare data for the tooltip
-* @return An array of tooltip data [{ title: ..., value: ...}]
-*/
-// TODO: add marktype
-function getTooltipData(item: SceneGraph, options: Option) {
-  // ignore the data for group type that represents white space
-  if (item.mark.marktype === 'group' && item.mark.name === 'nested_main_group') {
-    return undefined;
-  }
-
-  // this array will be bind to the tooltip element
-  let tooltipData: ToolTipData[];
-  const itemData: Map<any> = d3map(item.datum);
-
-  const removeKeys = [
-    '_id', '_prev', 'width', 'height',
-    'count_start', 'count_end',
-    'layout_start', 'layout_mid', 'layout_end', 'layout_path', 'layout_x', 'layout_y'
-  ];
-  removeFields(itemData, removeKeys);
-
-  // remove duplicate time fields (if any)
-  removeDuplicateTimeFields(itemData, options.fields);
-
-  // combine multiple rows of a binned field into a single row
-  combineBinFields(itemData, options.fields);
-
-  // TODO(zening): use Vega-Lite layering to support tooltip on line and area charts (#1)
-  dropFieldsForLineArea(item.mark.marktype, itemData);
-
-  if (options.showAllFields === true) {
-    tooltipData = prepareAllFieldsData(itemData, options);
-  } else {
-    tooltipData = prepareCustomFieldsData(itemData, options);
-  }
-
-  return tooltipData;
-}
-
-/**
-* Prepare custom fields data for tooltip. This function formats
-* field titles and values and returns an array of formatted fields.
-*
-* @param {time.map} itemData - a map of item.datum
-* @param {Object} options - user-provided options
-* @return An array of formatted fields specified by options [{ title: ..., value: ...}]
-*/
-function prepareCustomFieldsData(itemData: Map<any>, options: Option) {
-  const tooltipData: ToolTipData[] = [];
-
-  options.fields.forEach(function (fieldOption) {
-    // prepare field title
-    const title = fieldOption.title ? fieldOption.title : fieldOption.field;
-
-    // get (raw) field value
-    const value = getValue(itemData, fieldOption.field);
-    if (value === undefined) {
-      return undefined;
-    }
-
-    // format value
-    const formattedValue = customFormat(value, fieldOption.formatType, fieldOption.format) || autoFormat(value);
-
-    // add formatted data to tooltipData
-    tooltipData.push({title: title, value: formattedValue});
-
-  });
-
-  return tooltipData;
-}
-
-/**
-* Get a field value from a data map.
-* @param {time.map} itemData - a map of item.datum
-* @param {string} field - the name of the field. It can contain "." to specify
-* that the field is not a direct child of item.datum
-* @return the field value on success, undefined otherwise
-*/
-// TODO(zening): Mute "Cannot find field" warnings for composite vis (issue #39)
-function getValue(itemData: Map<any>, field: string) {
-  let value: string | number | Date;
-
-  const accessors: string[] = field.split('.');
-
-  // get the first accessor and remove it from the array
-  const firstAccessor: string = accessors[0];
-  accessors.shift();
-  if (itemData.has(firstAccessor)) {
-    value = itemData.get(firstAccessor);
-
-    // if we still have accessors, use them to get the value
-    accessors.forEach(function (a) {
-      if (value[a]) {
-        value = value[a];
-      }
-    });
-  }
-
-  if (value === undefined) {
-    console.warn('[Tooltip] Cannot find field ' + field + ' in data.');
-    return undefined;
-  } else {
-    return value;
-  }
-}
-
-
-/**
-* Prepare data for all fields in itemData for tooltip. This function
-* formats field titles and values and returns an array of formatted fields.
-*
-* @param {time.map} itemData - a map of item.datum
-* @param {Object} options - user-provided options
-* @return All fields in itemData, formatted, in the form of an array: [{ title: ..., value: ...}]
-*
-* Please note that this function expects itemData to be simple {field:value} pairs.
-* It will not try to parse value if it is an object. If value is an object, please
-* use prepareCustomFieldsData() instead.
-*/
-function prepareAllFieldsData(itemData: Map<any>, options: Option) {
-  const tooltipData: ToolTipData[] = [];
-
-  // here, fieldOptions still provides format
-  const fieldOptions = d3map(options.fields, function (d) { return d.field; });
-
-  itemData.each(function (value: string, field: string) {
-    // prepare title
-    let title;
-    if (fieldOptions.has(field) && fieldOptions.get(field).title) {
-      title = fieldOptions.get(field).title;
-    } else {
-      title = field;
-    }
-
-    let formatType;
-    let format;
-    // format value
-    if (fieldOptions.has(field)) {
-      formatType = fieldOptions.get(field).formatType;
-      format = fieldOptions.get(field).format;
-    }
-    const formattedValue = customFormat(value, formatType, format) || autoFormat(value);
-
-    // add formatted data to tooltipData
-    tooltipData.push({title: title, value: formattedValue});
-  });
-
-  return tooltipData;
-}
-
-/**
-* Remove multiple fields from a tooltip data map, using removeKeys
-*
-* Certain meta data fields (e.g. "_id", "_prev") should be hidden in the tooltip
-* by default. This function can be used to remove these fields from tooltip data.
-* @param {time.map} dataMap - the data map that contains tooltip data.
-* @param {string[]} removeKeys - the fields that should be removed from dataMap.
-*/
-function removeFields(dataMap: Map<any>, removeKeys: string[]) {
-  removeKeys.forEach(function (key) {
-    dataMap.remove(key);
-  });
-}
-
-/**
- * When a temporal field has timeUnit, itemData will give us duplicated fields
- * (e.g., Year and YEAR(Year)). In tooltip want to display the field WITH the
- * timeUnit and remove the field that doesn't have timeUnit.
- */
-function removeDuplicateTimeFields(itemData: Map<any>, optFields: SupplementedFieldOption[]) {
-  if (!optFields) {
-    return undefined;
-  }
-
-  optFields.forEach(function (optField) {
-    if (optField.removeOriginalTemporalField) {
-      removeFields(itemData, [optField.removeOriginalTemporalField]);
-    }
-  });
-}
-
-/**
-* Combine multiple binned fields in itemData into one field. The value of the field
-* is a string that describes the bin range.
-*
-* @param {time.map} itemData - a map of item.datum
-* @param {Object[]} fieldOptions - a list of field options (i.e. options.fields[])
-* @return itemData with combined bin fields
-*/
-function combineBinFields(itemData: Map<any>, fieldOptions: FieldOption[]) {
-  if (!fieldOptions) {
-    return undefined;
-  }
-
-  fieldOptions.forEach(function (fieldOption) {
-    if (fieldOption.bin === true) {
-      // get binned field names
-      const binFieldRange = fieldOption.field;
-      const binFieldStart = binFieldRange.concat('_start');
-      const binFieldMid = binFieldRange.concat('_mid');
-      const binFieldEnd = binFieldRange.concat('_end');
-
-      // use start value and end value to compute range
-      // save the computed range in binFieldStart
-      const startValue = itemData.get(binFieldStart);
-      const endValue = itemData.get(binFieldEnd);
-      if ((startValue !== undefined) && (endValue !== undefined)) {
-        const range = startValue + '-' + endValue;
-        itemData.set(binFieldRange, range);
-      }
-
-      // remove binFieldMid, binFieldEnd, and binFieldRange from itemData
-      const binRemoveKeys = [];
-      binRemoveKeys.push(binFieldStart, binFieldMid, binFieldEnd);
-      removeFields(itemData, binRemoveKeys);
-    }
-  });
-
-  return itemData;
-}
-
-/**
-* Drop fields for line and area marks.
-*
-* Lines and areas are defined by a series of datum. We overlay point marks
-* on top of lines and areas to allow tooltip to show all data in the series.
-* For the line marks and area marks underneath, we only show nominal fields
-* in tooltip. This is because line / area marks only give us the last datum
-* in their series. It only make sense to show the nominal fields (e.g., symbol
-* = APPL, AMZN, GOOG, IBM, MSFT) because these fields don't tend to change along
-* the line / area border.
-*/
-function dropFieldsForLineArea(marktype: string, itemData: Map<any>) {
-  if (marktype === 'line' || marktype === 'area') {
-    const quanKeys: string[] = [];
-    itemData.each(function (value, field) {
-        if (value instanceof Date) {
-          quanKeys.push(field);
-        }
-    });
-    removeFields(itemData, quanKeys);
-  }
-}
-
-/**
-* Format value using formatType and format
-* @param value - a field value to be formatted
-* @param formatType - the foramtType can be: "time", "number", or "string"
-* @param format - a time time format specifier, or a time number format specifier, or undefined
-* @return the formatted value, or undefined if value or formatType is missing
-*/
-function customFormat(value: number | string | Date, formatType: string, format: string): string {
-  if (value === undefined || value === null)  {
-    return undefined;
-  }
-  if (!formatType) {
-    return undefined;
-  }
-
-  switch (formatType) {
-    case 'time':
-      return format ? timeFormat(format)(value as Date) : autoTimeFormat(value as Date);
-    case 'number':
-      return format ? d3NumberFormat(format)(value as number) : autoNumberFormat(value as number);
-    case 'string':
-    default:
-      return value as string;
-  }
-}
-
-/**
-* Automatically format a time, number or string value
-* @return the formatted time, number or string value
-*/
-function autoFormat(value: string | number | Date): string {
-  if (typeof value === 'number') {
-    return autoNumberFormat(value);
-  } else if (value instanceof Date) {
-    return autoTimeFormat(value);
-  } else {
-    return value;
-  }
-}
-
-/**
- * Automatically format a number based on its decimal.
- * @param value number to be formatted
- * @return If it's a decimal number, return a fixed two points precision.
- * If it's a whole number, return the original value without any format.
- */
-function autoNumberFormat(value: number) {
-  return value % 1 === 0 ? d3NumberFormat(',')(value) : d3NumberFormat(',.2f')(value);
-}
-
-/**
- * Automatically format a time based on its date.
- * @param date object to be formatted
- * @return a formatted time string depending on the time. For example,
- * the start of February is formatted as "February", while February second is formatted as "Feb 2".
- */
-function autoTimeFormat(date: Date) {
-  const formatMillisecond = timeFormat('.%L'),
-    formatSecond = timeFormat(':%S'),
-    formatMinute = timeFormat('%I:%M'),
-    formatHour = timeFormat('%I %p'),
-    formatDay = timeFormat('%a %d'),
-    formatWeek = timeFormat('%b %d'),
-    formatMonth = timeFormat('%B'),
-    formatYear = timeFormat('%Y');
-
-  return (timeSecond(date) < date ? formatMillisecond
-      : timeMinute(date) < date ? formatSecond
-      : timeHour(date) < date ? formatMinute
-      : timeDay(date) < date ? formatHour
-      : timeMonth(date) < date ? (timeWeek(date) < date ? formatDay : formatWeek)
-      : timeYear(date) < date ? formatMonth
-      : formatYear)(date);
-}
-
-/**
-* Get the tooltip HTML placeholder by id selector "#vis-tooltip"
-* If none exists, create a placeholder.
-* @returns the HTML placeholder for tooltip
-*/
-function getTooltipPlaceholder() {
-  let tooltipPlaceholder;
-
-  if (select('#vis-tooltip').empty()) {
-    tooltipPlaceholder = select('body').append('div')
-      .attr('id', 'vis-tooltip')
-      .attr('class', 'vg-tooltip');
-  } else {
-    tooltipPlaceholder = select('#vis-tooltip');
-  }
-
-  return tooltipPlaceholder;
-}
-
-/**
-* Bind tooltipData to the tooltip placeholder
-*/
-function bindData(tooltipPlaceholder: Selection<Element | EnterElement | Document | Window, {}, HTMLElement, any>, tooltipData: ToolTipData[]) {
-  tooltipPlaceholder.selectAll('table').remove();
-  const tooltipRows = tooltipPlaceholder.append('table').selectAll('.tooltip-row')
-    .data(tooltipData);
-
-  tooltipRows.exit().remove();
-
-  const row = tooltipRows.enter().append('tr')
-    .attr('class', 'tooltip-row');
-  row.append('td').attr('class', 'key').text(function (d: ToolTipData) { return d.title + ':'; });
-  row.append('td').attr('class', 'value').text(function (d: ToolTipData) { return d.value; });
-}
-
-/**
-* Clear tooltip data
-*/
-function clearData() {
-  select('#vis-tooltip').selectAll('.tooltip-row').data([])
-    .exit().remove();
-}
-
-/**
-* Update tooltip position
-* Default position is 10px right of and 10px below the cursor. This can be
-* overwritten by options.offset
-*/
-function updatePosition(event: MouseEvent, options: Option) {
-  // determine x and y offsets, defaults are 10px
-  let offsetX = 10;
-  let offsetY = 10;
-  if (options && options.offset && (options.offset.x !== undefined) && (options.offset.x !== null)) {
-    offsetX = options.offset.x;
-  }
-  if (options && options.offset && (options.offset.y !== undefined) && (options.offset.y !== null)) {
-    offsetY = options.offset.y;
-  }
-
-  // TODO: use the correct time type
-  select('#vis-tooltip')
-    .style('top', function (this: HTMLElement) {
-      // by default: put tooltip 10px below cursor
-      // if tooltip is close to the bottom of the window, put tooltip 10px above cursor
-      const tooltipHeight = this.getBoundingClientRect().height;
-      if (event.clientY + tooltipHeight + offsetY < window.innerHeight) {
-        return '' + (event.clientY + offsetY) + 'px';
-      } else {
-        return '' + (event.clientY - tooltipHeight - offsetY) + 'px';
-      }
-    })
-    .style('left', function (this: HTMLElement) {
-      // by default: put tooltip 10px to the right of cursor
-      // if tooltip is close to the right edge of the window, put tooltip 10 px to the left of cursor
-      const tooltipWidth = this.getBoundingClientRect().width;
-      if (event.clientX + tooltipWidth + offsetX < window.innerWidth) {
-        return '' + (event.clientX + offsetX) + 'px';
-      } else {
-        return '' + (event.clientX - tooltipWidth - offsetX) + 'px';
-      }
-    });
-}
-
-/* Clear tooltip position */
-function clearPosition() {
-  select('#vis-tooltip')
-    .style('top', '-9999px')
-    .style('left', '-9999px');
-}
-
-/**
-* Update tooltip color theme according to options.colorTheme
-*
-* If colorTheme === "dark", apply dark theme to tooltip.
-* Otherwise apply light color theme.
-*/
-function updateColorTheme(options: Option) {
-  clearColorTheme();
-
-  if (options && options.colorTheme === 'dark') {
-    select('#vis-tooltip').classed('dark-theme', true);
-  } else {
-    select('#vis-tooltip').classed('light-theme', true);
-  }
-}
-
-/* Clear color themes */
-function clearColorTheme() {
-  select('#vis-tooltip').classed('dark-theme light-theme', false);
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -20,3 +20,26 @@ export interface FieldOption {
   aggregate?: string;
   bin?: boolean;
 }
+
+export interface SupplementedFieldOption extends FieldOption {
+  removeOriginalTemporalField?: string;
+  bin?: boolean;
+}
+
+export type TooltipData = {title: string, value: string | number };
+
+export type Scenegraph = {
+  datum: {
+    _facetID: number,
+    _id: number
+  },
+  mark: {
+    marktype: string,
+    items: object,
+    name: string
+  }
+};
+
+export type VgView = any;
+
+export const DELAY = 100;

--- a/src/options.ts
+++ b/src/options.ts
@@ -26,7 +26,7 @@ export interface SupplementedFieldOption extends FieldOption {
   bin?: boolean;
 }
 
-export type TooltipData = {title: string, value: string | number };
+export type TooltipData = {title: string, value: string | number};
 
 export type Scenegraph = {
   datum: {

--- a/src/parseOption.ts
+++ b/src/parseOption.ts
@@ -3,9 +3,9 @@ import {autoFormat, customFormat} from './formatFieldValue';
 import {FieldOption, Option, Scenegraph, SupplementedFieldOption, TooltipData} from './options';
 
 /**
-* Prepare data for the tooltip
-* @return An array of tooltip data [{ title: ..., value: ...}]
-*/
+ * Prepare data for the tooltip
+ * @return An array of tooltip data [{ title: ..., value: ...}]
+ */
 // TODO: add marktype
 export function getTooltipData(item: Scenegraph, options: Option) {
   // ignore the data for group type that represents white space
@@ -43,13 +43,13 @@ export function getTooltipData(item: Scenegraph, options: Option) {
 }
 
 /**
-* Prepare custom fields data for tooltip. This function formats
-* field titles and values and returns an array of formatted fields.
-*
-* @param {time.map} itemData - a map of item.datum
-* @param {Object} options - user-provided options
-* @return An array of formatted fields specified by options [{ title: ..., value: ...}]
-*/
+ * Prepare custom fields data for tooltip. This function formats
+ * field titles and values and returns an array of formatted fields.
+ *
+ * @param {time.map} itemData - a map of item.datum
+ * @param {Object} options - user-provided options
+ * @return An array of formatted fields specified by options [{ title: ..., value: ...}]
+ */
 export function prepareCustomFieldsData(itemData: Map<any>, options: Option) {
   const tooltipData: TooltipData[] = [];
 
@@ -75,12 +75,12 @@ export function prepareCustomFieldsData(itemData: Map<any>, options: Option) {
 }
 
 /**
-* Get a field value from a data map.
-* @param {time.map} itemData - a map of item.datum
-* @param {string} field - the name of the field. It can contain "." to specify
-* that the field is not a direct child of item.datum
-* @return the field value on success, undefined otherwise
-*/
+ * Get a field value from a data map.
+ * @param {time.map} itemData - a map of item.datum
+ * @param {string} field - the name of the field. It can contain "." to specify
+ * that the field is not a direct child of item.datum
+ * @return the field value on success, undefined otherwise
+ */
 // TODO(zening): Mute "Cannot find field" warnings for composite vis (issue #39)
 export function getValue(itemData: Map<any>, field: string) {
   let value: string | number | Date;
@@ -111,17 +111,17 @@ export function getValue(itemData: Map<any>, field: string) {
 
 
 /**
-* Prepare data for all fields in itemData for tooltip. This function
-* formats field titles and values and returns an array of formatted fields.
-*
-* @param {time.map} itemData - a map of item.datum
-* @param {Object} options - user-provided options
-* @return All fields in itemData, formatted, in the form of an array: [{ title: ..., value: ...}]
-*
-* Please note that this function expects itemData to be simple {field:value} pairs.
-* It will not try to parse value if it is an object. If value is an object, please
-* use prepareCustomFieldsData() instead.
-*/
+ * Prepare data for all fields in itemData for tooltip. This function
+ * formats field titles and values and returns an array of formatted fields.
+ *
+ * @param {time.map} itemData - a map of item.datum
+ * @param {Object} options - user-provided options
+ * @return All fields in itemData, formatted, in the form of an array: [{ title: ..., value: ...}]
+ *
+ * Please note that this function expects itemData to be simple {field:value} pairs.
+ * It will not try to parse value if it is an object. If value is an object, please
+ * use prepareCustomFieldsData() instead.
+ */
 export function prepareAllFieldsData(itemData: Map<any>, options: Option) {
   const tooltipData: TooltipData[] = [];
 
@@ -154,13 +154,13 @@ export function prepareAllFieldsData(itemData: Map<any>, options: Option) {
 }
 
 /**
-* Remove multiple fields from a tooltip data map, using removeKeys
-*
-* Certain meta data fields (e.g. "_id", "_prev") should be hidden in the tooltip
-* by default. This function can be used to remove these fields from tooltip data.
-* @param {time.map} dataMap - the data map that contains tooltip data.
-* @param {string[]} removeKeys - the fields that should be removed from dataMap.
-*/
+ * Remove multiple fields from a tooltip data map, using removeKeys
+ *
+ * Certain meta data fields (e.g. "_id", "_prev") should be hidden in the tooltip
+ * by default. This function can be used to remove these fields from tooltip data.
+ * @param {time.map} dataMap - the data map that contains tooltip data.
+ * @param {string[]} removeKeys - the fields that should be removed from dataMap.
+ */
 export function removeFields(dataMap: Map<any>, removeKeys: string[]) {
   removeKeys.forEach(function (key) {
     dataMap.remove(key);
@@ -185,13 +185,13 @@ export function removeDuplicateTimeFields(itemData: Map<any>, optFields: Supplem
 }
 
 /**
-* Combine multiple binned fields in itemData into one field. The value of the field
-* is a string that describes the bin range.
-*
-* @param {time.map} itemData - a map of item.datum
-* @param {Object[]} fieldOptions - a list of field options (i.e. options.fields[])
-* @return itemData with combined bin fields
-*/
+ * Combine multiple binned fields in itemData into one field. The value of the field
+ * is a string that describes the bin range.
+ *
+ * @param {time.map} itemData - a map of item.datum
+ * @param {Object[]} fieldOptions - a list of field options (i.e. options.fields[])
+ * @return itemData with combined bin fields
+ */
 export function combineBinFields(itemData: Map<any>, fieldOptions: FieldOption[]) {
   if (!fieldOptions) {
     return undefined;
@@ -225,23 +225,23 @@ export function combineBinFields(itemData: Map<any>, fieldOptions: FieldOption[]
 }
 
 /**
-* Drop fields for line and area marks.
-*
-* Lines and areas are defined by a series of datum. We overlay point marks
-* on top of lines and areas to allow tooltip to show all data in the series.
-* For the line marks and area marks underneath, we only show nominal fields
-* in tooltip. This is because line / area marks only give us the last datum
-* in their series. It only make sense to show the nominal fields (e.g., symbol
-* = APPL, AMZN, GOOG, IBM, MSFT) because these fields don't tend to change along
-* the line / area border.
-*/
+ * Drop fields for line and area marks.
+ *
+ * Lines and areas are defined by a series of datum. We overlay point marks
+ * on top of lines and areas to allow tooltip to show all data in the series.
+ * For the line marks and area marks underneath, we only show nominal fields
+ * in tooltip. This is because line / area marks only give us the last datum
+ * in their series. It only make sense to show the nominal fields (e.g., symbol
+ * = APPL, AMZN, GOOG, IBM, MSFT) because these fields don't tend to change along
+ * the line / area border.
+ */
 export function dropFieldsForLineArea(marktype: string, itemData: Map<any>) {
   if (marktype === 'line' || marktype === 'area') {
     const quanKeys: string[] = [];
     itemData.each(function (value, field) {
-        if (value instanceof Date) {
-          quanKeys.push(field);
-        }
+      if (value instanceof Date) {
+        quanKeys.push(field);
+      }
     });
     removeFields(itemData, quanKeys);
   }

--- a/src/parseOption.ts
+++ b/src/parseOption.ts
@@ -1,0 +1,248 @@
+import {Map, map as d3map} from 'd3-collection';
+import {autoFormat, customFormat} from './formatFieldValue';
+import {FieldOption, Option, Scenegraph, SupplementedFieldOption, TooltipData} from './options';
+
+/**
+* Prepare data for the tooltip
+* @return An array of tooltip data [{ title: ..., value: ...}]
+*/
+// TODO: add marktype
+export function getTooltipData(item: Scenegraph, options: Option) {
+  // ignore the data for group type that represents white space
+  if (item.mark.marktype === 'group' && item.mark.name === 'nested_main_group') {
+    return undefined;
+  }
+
+  // this array will be bind to the tooltip element
+  let tooltipData: TooltipData[];
+  const itemData: Map<any> = d3map(item.datum);
+
+  const removeKeys = [
+    '_id', '_prev', 'width', 'height',
+    'count_start', 'count_end',
+    'layout_start', 'layout_mid', 'layout_end', 'layout_path', 'layout_x', 'layout_y'
+  ];
+  removeFields(itemData, removeKeys);
+
+  // remove duplicate time fields (if any)
+  removeDuplicateTimeFields(itemData, options.fields);
+
+  // combine multiple rows of a binned field into a single row
+  combineBinFields(itemData, options.fields);
+
+  // TODO(zening): use Vega-Lite layering to support tooltip on line and area charts (#1)
+  dropFieldsForLineArea(item.mark.marktype, itemData);
+
+  if (options.showAllFields === true) {
+    tooltipData = prepareAllFieldsData(itemData, options);
+  } else {
+    tooltipData = prepareCustomFieldsData(itemData, options);
+  }
+
+  return tooltipData;
+}
+
+/**
+* Prepare custom fields data for tooltip. This function formats
+* field titles and values and returns an array of formatted fields.
+*
+* @param {time.map} itemData - a map of item.datum
+* @param {Object} options - user-provided options
+* @return An array of formatted fields specified by options [{ title: ..., value: ...}]
+*/
+export function prepareCustomFieldsData(itemData: Map<any>, options: Option) {
+  const tooltipData: TooltipData[] = [];
+
+  options.fields.forEach(function (fieldOption) {
+    // prepare field title
+    const title = fieldOption.title ? fieldOption.title : fieldOption.field;
+
+    // get (raw) field value
+    const value = getValue(itemData, fieldOption.field);
+    if (value === undefined) {
+      return undefined;
+    }
+
+    // format value
+    const formattedValue = customFormat(value, fieldOption.formatType, fieldOption.format) || autoFormat(value);
+
+    // add formatted data to tooltipData
+    tooltipData.push({title: title, value: formattedValue});
+
+  });
+
+  return tooltipData;
+}
+
+/**
+* Get a field value from a data map.
+* @param {time.map} itemData - a map of item.datum
+* @param {string} field - the name of the field. It can contain "." to specify
+* that the field is not a direct child of item.datum
+* @return the field value on success, undefined otherwise
+*/
+// TODO(zening): Mute "Cannot find field" warnings for composite vis (issue #39)
+export function getValue(itemData: Map<any>, field: string) {
+  let value: string | number | Date;
+
+  const accessors: string[] = field.split('.');
+
+  // get the first accessor and remove it from the array
+  const firstAccessor: string = accessors[0];
+  accessors.shift();
+  if (itemData.has(firstAccessor)) {
+    value = itemData.get(firstAccessor);
+
+    // if we still have accessors, use them to get the value
+    accessors.forEach(function (a) {
+      if (value[a]) {
+        value = value[a];
+      }
+    });
+  }
+
+  if (value === undefined) {
+    console.warn('[Tooltip] Cannot find field ' + field + ' in data.');
+    return undefined;
+  } else {
+    return value;
+  }
+}
+
+
+/**
+* Prepare data for all fields in itemData for tooltip. This function
+* formats field titles and values and returns an array of formatted fields.
+*
+* @param {time.map} itemData - a map of item.datum
+* @param {Object} options - user-provided options
+* @return All fields in itemData, formatted, in the form of an array: [{ title: ..., value: ...}]
+*
+* Please note that this function expects itemData to be simple {field:value} pairs.
+* It will not try to parse value if it is an object. If value is an object, please
+* use prepareCustomFieldsData() instead.
+*/
+export function prepareAllFieldsData(itemData: Map<any>, options: Option) {
+  const tooltipData: TooltipData[] = [];
+
+  // here, fieldOptions still provides format
+  const fieldOptions = d3map(options.fields, function (d) { return d.field; });
+
+  itemData.each(function (value: string, field: string) {
+    // prepare title
+    let title;
+    if (fieldOptions.has(field) && fieldOptions.get(field).title) {
+      title = fieldOptions.get(field).title;
+    } else {
+      title = field;
+    }
+
+    let formatType;
+    let format;
+    // format value
+    if (fieldOptions.has(field)) {
+      formatType = fieldOptions.get(field).formatType;
+      format = fieldOptions.get(field).format;
+    }
+    const formattedValue = customFormat(value, formatType, format) || autoFormat(value);
+
+    // add formatted data to tooltipData
+    tooltipData.push({title: title, value: formattedValue});
+  });
+
+  return tooltipData;
+}
+
+/**
+* Remove multiple fields from a tooltip data map, using removeKeys
+*
+* Certain meta data fields (e.g. "_id", "_prev") should be hidden in the tooltip
+* by default. This function can be used to remove these fields from tooltip data.
+* @param {time.map} dataMap - the data map that contains tooltip data.
+* @param {string[]} removeKeys - the fields that should be removed from dataMap.
+*/
+export function removeFields(dataMap: Map<any>, removeKeys: string[]) {
+  removeKeys.forEach(function (key) {
+    dataMap.remove(key);
+  });
+}
+
+/**
+ * When a temporal field has timeUnit, itemData will give us duplicated fields
+ * (e.g., Year and YEAR(Year)). In tooltip want to display the field WITH the
+ * timeUnit and remove the field that doesn't have timeUnit.
+ */
+export function removeDuplicateTimeFields(itemData: Map<any>, optFields: SupplementedFieldOption[]) {
+  if (!optFields) {
+    return undefined;
+  }
+
+  optFields.forEach(function (optField) {
+    if (optField.removeOriginalTemporalField) {
+      removeFields(itemData, [optField.removeOriginalTemporalField]);
+    }
+  });
+}
+
+/**
+* Combine multiple binned fields in itemData into one field. The value of the field
+* is a string that describes the bin range.
+*
+* @param {time.map} itemData - a map of item.datum
+* @param {Object[]} fieldOptions - a list of field options (i.e. options.fields[])
+* @return itemData with combined bin fields
+*/
+export function combineBinFields(itemData: Map<any>, fieldOptions: FieldOption[]) {
+  if (!fieldOptions) {
+    return undefined;
+  }
+
+  fieldOptions.forEach(function (fieldOption) {
+    if (fieldOption.bin === true) {
+      // get binned field names
+      const binFieldRange = fieldOption.field;
+      const binFieldStart = binFieldRange.concat('_start');
+      const binFieldMid = binFieldRange.concat('_mid');
+      const binFieldEnd = binFieldRange.concat('_end');
+
+      // use start value and end value to compute range
+      // save the computed range in binFieldStart
+      const startValue = itemData.get(binFieldStart);
+      const endValue = itemData.get(binFieldEnd);
+      if ((startValue !== undefined) && (endValue !== undefined)) {
+        const range = startValue + '-' + endValue;
+        itemData.set(binFieldRange, range);
+      }
+
+      // remove binFieldMid, binFieldEnd, and binFieldRange from itemData
+      const binRemoveKeys = [];
+      binRemoveKeys.push(binFieldStart, binFieldMid, binFieldEnd);
+      removeFields(itemData, binRemoveKeys);
+    }
+  });
+
+  return itemData;
+}
+
+/**
+* Drop fields for line and area marks.
+*
+* Lines and areas are defined by a series of datum. We overlay point marks
+* on top of lines and areas to allow tooltip to show all data in the series.
+* For the line marks and area marks underneath, we only show nominal fields
+* in tooltip. This is because line / area marks only give us the last datum
+* in their series. It only make sense to show the nominal fields (e.g., symbol
+* = APPL, AMZN, GOOG, IBM, MSFT) because these fields don't tend to change along
+* the line / area border.
+*/
+export function dropFieldsForLineArea(marktype: string, itemData: Map<any>) {
+  if (marktype === 'line' || marktype === 'area') {
+    const quanKeys: string[] = [];
+    itemData.each(function (value, field) {
+        if (value instanceof Date) {
+          quanKeys.push(field);
+        }
+    });
+    removeFields(itemData, quanKeys);
+  }
+}

--- a/src/supplementField.ts
+++ b/src/supplementField.ts
@@ -1,0 +1,237 @@
+import * as vl from 'vega-lite';
+import {FieldDef} from 'vega-lite/build/src/fielddef';
+import {TopLevelExtendedSpec} from 'vega-lite/build/src/spec';
+import {TEMPORAL} from 'vega-lite/build/src/type';
+import {FieldOption, Option} from './options';
+import {SupplementedFieldOption} from './options';
+
+/* mapping from fieldDef.type to formatType */
+const formatTypeMap: {[type: string]: 'number' | 'time'} = {
+  'quantitative': 'number',
+  'temporal': 'time',
+  'ordinal': undefined,
+  'nominal': undefined
+};
+
+/**
+* (Vega-Lite only) Supplement options with vlSpec
+*
+* @param options - user-provided options
+* @param vlSpec - vega-lite spec
+* @return the vlSpec-supplemented options object
+*
+* if options.showAllFields is true or undefined, vlSpec will supplement
+* options.fields with all fields in the spec
+* if options.showAllFields is false, vlSpec will only supplement existing fields
+* in options.fields
+*/
+
+export function supplementOptions(options: Option, vlSpec: TopLevelExtendedSpec) {
+  // fields to be supplemented by vlSpec
+  const supplementedFields: FieldOption[] = [];
+
+  // if showAllFields is true or undefined, supplement all fields in vlSpec
+  if (options.showAllFields !== false) {
+    vl.spec.fieldDefs(vlSpec).forEach(function (fieldDef: FieldDef<string>) {
+      // get a fieldOption in options that matches the fieldDef
+      const fieldOption = getFieldOption(options.fields, fieldDef);
+
+      // supplement the fieldOption with fieldDef and config
+      const supplementedFieldOption = supplementFieldOption(fieldOption, fieldDef, vlSpec);
+
+      supplementedFields.push(supplementedFieldOption);
+    });
+  } else { // if showAllFields is false, only supplement existing fields in options.fields
+    if (options.fields) {
+      options.fields.forEach(function (fieldOption: FieldOption) {
+        // get the fieldDef in vlSpec that matches the fieldOption
+        const fieldDef = getFieldDef(vl.spec.fieldDefs(vlSpec) as FieldDef<string>[], fieldOption);
+
+        // supplement the fieldOption with fieldDef and config
+        const supplementedFieldOption = supplementFieldOption(fieldOption, fieldDef, vlSpec);
+
+        supplementedFields.push(supplementedFieldOption);
+      });
+    }
+  }
+
+  options.fields = supplementedFields;
+
+  return options;
+}
+
+/**
+* Find a fieldOption in fieldOptions that matches a fieldDef
+*
+* @param {Object[]} fieldOptionss - a list of field options (i.e. options.fields[])
+* @param {Object} fieldDef - from vlSpec
+* @return the matching fieldOption, or undefined if no match was found
+*
+* If the fieldDef is aggregated, find a fieldOption that matches the field name and
+* the aggregation of the fieldDef.
+* If the fieldDef is not aggregated, find a fieldOption that matches the field name.
+*/
+export function getFieldOption(fieldOptions: FieldOption[], fieldDef: FieldDef<string>) {
+  if (!fieldDef || !fieldOptions || fieldOptions.length <= 0) {
+    return undefined;
+  }
+
+  // if aggregate, match field name and aggregate operation
+  if (fieldDef.aggregate) {
+    // try find the perfect match: field name equals, aggregate operation equals
+    for (let item of fieldOptions) {
+      if (item.field === fieldDef.field && item.aggregate === fieldDef.aggregate) {
+        return item;
+      }
+    }
+
+    // try find the second-best match: field name equals, field.aggregate is not specified
+    for (let item of fieldOptions) {
+      if (item.field === fieldDef.field && !item.aggregate) {
+        return item;
+      }
+    }
+
+    // return undefined if no match was found
+    return undefined;
+  } else { // if not aggregate, just match field name
+    for (let item of fieldOptions) {
+      if (item.field === fieldDef.field) {
+        return item;
+      }
+    }
+
+    // return undefined if no match was found
+    return undefined;
+  }
+}
+
+/**
+* Find a fieldDef that matches a fieldOption
+*
+* @param {Object} fieldOption - a field option (a member in options.fields[])
+* @return the matching fieldDef, or undefined if no match was found
+*
+* A matching fieldDef should have the same field name as fieldOption.
+* If the matching fieldDef is aggregated, the aggregation should not contradict
+* with that of the fieldOption.
+*/
+export function getFieldDef(fieldDefs: FieldDef<string>[], fieldOption: FieldOption): FieldDef<string> {
+  if (!fieldOption || !fieldOption.field || !fieldDefs) {
+    return undefined;
+  }
+
+  // field name should match, aggregation should not disagree
+  for (let item of fieldDefs) {
+    if (item.field === fieldOption.field) {
+      if (item.aggregate) {
+        if (item.aggregate === fieldOption.aggregate || !fieldOption.aggregate) {
+          return item;
+        }
+      } else {
+        return item;
+      }
+    }
+  }
+
+  // return undefined if no match was found
+  return undefined;
+}
+
+/**
+* Supplement a fieldOption (from options.fields[]) with a fieldDef, config
+* (which provides timeFormat, numberFormat, countTitle)
+* Either fieldOption or fieldDef can be undefined, but they cannot both be undefined.
+* config (and its members timeFormat, numberFormat and countTitle) can be undefined.
+* @return the supplemented fieldOption, or undefined on error
+*/
+export function supplementFieldOption(fieldOption: FieldOption, fieldDef: FieldDef<string>, vlSpec: TopLevelExtendedSpec) {
+  // many specs don't have config
+  const config = vl.util.extend({}, vlSpec.config);
+
+  // at least one of fieldOption and fieldDef should exist
+  if (!fieldOption && !fieldDef) {
+    console.error('[Tooltip] Cannot supplement a field when field and fieldDef are both empty.');
+    return undefined;
+  }
+
+  // if either one of fieldOption and fieldDef is undefined, make it an empty object
+  if (!fieldOption && fieldDef) {
+    fieldOption = {};
+  }
+  if (fieldOption && !fieldDef) {
+    fieldDef = {};
+  }
+
+  // the supplemented field option
+  const supplementedFieldOption: SupplementedFieldOption = {};
+
+  // supplement a user-provided field name with underscore prefixes and suffixes to
+  // match the field names in item.datum
+  // for aggregation, this will add prefix "mean_" etc.
+  // for timeUnit, this will add prefix "yearmonth_" etc.
+  // for bin, this will add prefix "bin_" and suffix "_start". Later we will replace "_start" with "_range".
+  supplementedFieldOption.field = fieldDef.field ?
+    vl.fieldDef.field(fieldDef) : fieldOption.field;
+
+  // If a fieldDef is a (TIMEUNIT)T, we check if the original T is present in the vlSpec.
+  // If only (TIMEUNIT)T is present in vlSpec, we set `removeOriginalTemporalField` to T,
+  // which will cause function removeDuplicateTimeFields() to remove T and only keep (TIMEUNIT)T
+  // in item data.
+  // If both (TIMEUNIT)T and T are in vlSpec, we set `removeOriginalTemporalField` to undefined,
+  // which will leave both T and (TIMEUNIT)T in item data.
+  // Note: user should never have to provide this boolean in options
+  if (fieldDef.type === TEMPORAL && fieldDef.timeUnit) {
+    // in most cases, if it's a (TIMEUNIT)T, we remove original T
+    const originalTemporalField = fieldDef.field;
+    supplementedFieldOption.removeOriginalTemporalField = originalTemporalField;
+
+    // handle corner case: if T is present in vlSpec, then we keep both T and (TIMEUNIT)T
+    const fieldDefs = vl.spec.fieldDefs(vlSpec);
+    for (let items of fieldDefs) {
+      if (items.field === originalTemporalField && !items.timeUnit) {
+        supplementedFieldOption.removeOriginalTemporalField = undefined;
+        break;
+      }
+    }
+  }
+
+  // supplement title
+  if (!config.countTitle) {
+    config.countTitle = vl.config.defaultConfig.countTitle; // use vl default countTitle
+  }
+  supplementedFieldOption.title = fieldOption.title ?
+    fieldOption.title : vl.fieldDef.title(fieldDef, config);
+
+  // supplement formatType
+  supplementedFieldOption.formatType = fieldOption.formatType ?
+    fieldOption.formatType : formatTypeMap[fieldDef.type];
+
+  // supplement format
+  if (fieldOption.format) {
+    supplementedFieldOption.format = fieldOption.format;
+  } else { // when user doesn't provide format, supplement format using timeUnit, timeFormat, and numberFormat
+    switch (supplementedFieldOption.formatType) {
+      case 'time':
+        supplementedFieldOption.format = fieldDef.timeUnit ?
+          // TODO(zening): use template for all time fields, to be consistent with Vega-Lite
+          vl.timeUnit.formatExpression(fieldDef.timeUnit, '', false).split("'")[1]
+          : config.timeFormat || vl.config.defaultConfig.timeFormat;
+        break;
+      case 'number':
+        supplementedFieldOption.format = config.numberFormat;
+        break;
+      case 'string':
+      default:
+    }
+  }
+
+  // supplement bin from fieldDef, user should never have to provide bin in options
+  if (fieldDef.bin) {
+    supplementedFieldOption.field = supplementedFieldOption.field.replace('_start', '_range'); // replace suffix
+    supplementedFieldOption.bin = true;
+    supplementedFieldOption.formatType = 'string'; // we show bin range as string (e.g. "5-10")
+  }
+
+  return supplementedFieldOption;
+}

--- a/src/supplementField.ts
+++ b/src/supplementField.ts
@@ -6,7 +6,7 @@ import {FieldOption, Option} from './options';
 import {SupplementedFieldOption} from './options';
 
 /* mapping from fieldDef.type to formatType */
-const formatTypeMap: {[type: string]: 'number' | 'time'} = {
+const formatTypeMap: { [type: string]: 'number' | 'time' } = {
   'quantitative': 'number',
   'temporal': 'time',
   'ordinal': undefined,
@@ -14,18 +14,17 @@ const formatTypeMap: {[type: string]: 'number' | 'time'} = {
 };
 
 /**
-* (Vega-Lite only) Supplement options with vlSpec
-*
-* @param options - user-provided options
-* @param vlSpec - vega-lite spec
-* @return the vlSpec-supplemented options object
-*
-* if options.showAllFields is true or undefined, vlSpec will supplement
-* options.fields with all fields in the spec
-* if options.showAllFields is false, vlSpec will only supplement existing fields
-* in options.fields
-*/
-
+ * (Vega-Lite only) Supplement options with vlSpec
+ *
+ * @param options - user-provided options
+ * @param vlSpec - vega-lite spec
+ * @return the vlSpec-supplemented options object
+ *
+ * if options.showAllFields is true or undefined, vlSpec will supplement
+ * options.fields with all fields in the spec
+ * if options.showAllFields is false, vlSpec will only supplement existing fields
+ * in options.fields
+ */
 export function supplementOptions(options: Option, vlSpec: TopLevelExtendedSpec) {
   // fields to be supplemented by vlSpec
   const supplementedFields: FieldOption[] = [];
@@ -61,16 +60,16 @@ export function supplementOptions(options: Option, vlSpec: TopLevelExtendedSpec)
 }
 
 /**
-* Find a fieldOption in fieldOptions that matches a fieldDef
-*
-* @param {Object[]} fieldOptionss - a list of field options (i.e. options.fields[])
-* @param {Object} fieldDef - from vlSpec
-* @return the matching fieldOption, or undefined if no match was found
-*
-* If the fieldDef is aggregated, find a fieldOption that matches the field name and
-* the aggregation of the fieldDef.
-* If the fieldDef is not aggregated, find a fieldOption that matches the field name.
-*/
+ * Find a fieldOption in fieldOptions that matches a fieldDef
+ *
+ * @param {Object[]} fieldOptionss - a list of field options (i.e. options.fields[])
+ * @param {Object} fieldDef - from vlSpec
+ * @return the matching fieldOption, or undefined if no match was found
+ *
+ * If the fieldDef is aggregated, find a fieldOption that matches the field name and
+ * the aggregation of the fieldDef.
+ * If the fieldDef is not aggregated, find a fieldOption that matches the field name.
+ */
 export function getFieldOption(fieldOptions: FieldOption[], fieldDef: FieldDef<string>) {
   if (!fieldDef || !fieldOptions || fieldOptions.length <= 0) {
     return undefined;
@@ -107,15 +106,15 @@ export function getFieldOption(fieldOptions: FieldOption[], fieldDef: FieldDef<s
 }
 
 /**
-* Find a fieldDef that matches a fieldOption
-*
-* @param {Object} fieldOption - a field option (a member in options.fields[])
-* @return the matching fieldDef, or undefined if no match was found
-*
-* A matching fieldDef should have the same field name as fieldOption.
-* If the matching fieldDef is aggregated, the aggregation should not contradict
-* with that of the fieldOption.
-*/
+ * Find a fieldDef that matches a fieldOption
+ *
+ * @param {Object} fieldOption - a field option (a member in options.fields[])
+ * @return the matching fieldDef, or undefined if no match was found
+ *
+ * A matching fieldDef should have the same field name as fieldOption.
+ * If the matching fieldDef is aggregated, the aggregation should not contradict
+ * with that of the fieldOption.
+ */
 export function getFieldDef(fieldDefs: FieldDef<string>[], fieldOption: FieldOption): FieldDef<string> {
   if (!fieldOption || !fieldOption.field || !fieldDefs) {
     return undefined;
@@ -139,12 +138,12 @@ export function getFieldDef(fieldDefs: FieldDef<string>[], fieldOption: FieldOpt
 }
 
 /**
-* Supplement a fieldOption (from options.fields[]) with a fieldDef, config
-* (which provides timeFormat, numberFormat, countTitle)
-* Either fieldOption or fieldDef can be undefined, but they cannot both be undefined.
-* config (and its members timeFormat, numberFormat and countTitle) can be undefined.
-* @return the supplemented fieldOption, or undefined on error
-*/
+ * Supplement a fieldOption (from options.fields[]) with a fieldDef, config
+ * (which provides timeFormat, numberFormat, countTitle)
+ * Either fieldOption or fieldDef can be undefined, but they cannot both be undefined.
+ * config (and its members timeFormat, numberFormat and countTitle) can be undefined.
+ * @return the supplemented fieldOption, or undefined on error
+ */
 export function supplementFieldOption(fieldOption: FieldOption, fieldDef: FieldDef<string>, vlSpec: TopLevelExtendedSpec) {
   // many specs don't have config
   const config = vl.util.extend({}, vlSpec.config);

--- a/src/supplementedFieldOption.ts
+++ b/src/supplementedFieldOption.ts
@@ -1,5 +1,0 @@
-import {FieldOption} from './options';
-export interface SupplementedFieldOption extends FieldOption {
-  removeOriginalTemporalField?: string;
-  bin?: boolean;
-}

--- a/src/tooltipDisplay.ts
+++ b/src/tooltipDisplay.ts
@@ -1,0 +1,113 @@
+import {EnterElement, select, Selection} from 'd3-selection';
+import {Option, TooltipData} from './options';
+
+/**
+* Get the tooltip HTML placeholder by id selector "#vis-tooltip"
+* If none exists, create a placeholder.
+* @returns the HTML placeholder for tooltip
+*/
+export function getTooltipPlaceholder() {
+  let tooltipPlaceholder;
+
+  if (select('#vis-tooltip').empty()) {
+    tooltipPlaceholder = select('body').append('div')
+      .attr('id', 'vis-tooltip')
+      .attr('class', 'vg-tooltip');
+  } else {
+    tooltipPlaceholder = select('#vis-tooltip');
+  }
+
+  return tooltipPlaceholder;
+}
+
+/**
+* Bind tooltipData to the tooltip placeholder
+*/
+export function bindData(tooltipPlaceholder: Selection<Element | EnterElement | Document | Window, {}, HTMLElement, any>, tooltipData: TooltipData[]) {
+  tooltipPlaceholder.selectAll('table').remove();
+  const tooltipRows = tooltipPlaceholder.append('table').selectAll('.tooltip-row')
+    .data(tooltipData);
+
+  tooltipRows.exit().remove();
+
+  const row = tooltipRows.enter().append('tr')
+    .attr('class', 'tooltip-row');
+  row.append('td').attr('class', 'key').text(function (d: TooltipData) { return d.title + ':'; });
+  row.append('td').attr('class', 'value').text(function (d: TooltipData) { return d.value; });
+}
+
+/**
+* Clear tooltip data
+*/
+export function clearData() {
+  select('#vis-tooltip').selectAll('.tooltip-row').data([])
+    .exit().remove();
+}
+
+/**
+* Update tooltip position
+* Default position is 10px right of and 10px below the cursor. This can be
+* overwritten by options.offset
+*/
+export function updatePosition(event: MouseEvent, options: Option) {
+  // determine x and y offsets, defaults are 10px
+  let offsetX = 10;
+  let offsetY = 10;
+  if (options && options.offset && (options.offset.x !== undefined) && (options.offset.x !== null)) {
+    offsetX = options.offset.x;
+  }
+  if (options && options.offset && (options.offset.y !== undefined) && (options.offset.y !== null)) {
+    offsetY = options.offset.y;
+  }
+
+  // TODO: use the correct time type
+  select('#vis-tooltip')
+    .style('top', function (this: HTMLElement) {
+      // by default: put tooltip 10px below cursor
+      // if tooltip is close to the bottom of the window, put tooltip 10px above cursor
+      const tooltipHeight = this.getBoundingClientRect().height;
+      if (event.clientY + tooltipHeight + offsetY < window.innerHeight) {
+        return '' + (event.clientY + offsetY) + 'px';
+      } else {
+        return '' + (event.clientY - tooltipHeight - offsetY) + 'px';
+      }
+    })
+    .style('left', function (this: HTMLElement) {
+      // by default: put tooltip 10px to the right of cursor
+      // if tooltip is close to the right edge of the window, put tooltip 10 px to the left of cursor
+      const tooltipWidth = this.getBoundingClientRect().width;
+      if (event.clientX + tooltipWidth + offsetX < window.innerWidth) {
+        return '' + (event.clientX + offsetX) + 'px';
+      } else {
+        return '' + (event.clientX - tooltipWidth - offsetX) + 'px';
+      }
+    });
+}
+
+/* Clear tooltip position */
+export function clearPosition() {
+  select('#vis-tooltip')
+    .style('top', '-9999px')
+    .style('left', '-9999px');
+}
+
+/**
+* Update tooltip color theme according to options.colorTheme
+*
+* If colorTheme === "dark", apply dark theme to tooltip.
+* Otherwise apply light color theme.
+*/
+export function updateColorTheme(options: Option) {
+  clearColorTheme();
+
+  if (options && options.colorTheme === 'dark') {
+    select('#vis-tooltip').classed('dark-theme', true);
+  } else {
+    select('#vis-tooltip').classed('light-theme', true);
+  }
+}
+
+/* Clear color themes */
+export function clearColorTheme() {
+  select('#vis-tooltip').classed('dark-theme light-theme', false);
+}

--- a/src/tooltipDisplay.ts
+++ b/src/tooltipDisplay.ts
@@ -1,11 +1,11 @@
-import {EnterElement, select, Selection} from 'd3-selection';
-import {Option, TooltipData} from './options';
+import { EnterElement, select, Selection } from 'd3-selection';
+import { Option, TooltipData } from './options';
 
 /**
-* Get the tooltip HTML placeholder by id selector "#vis-tooltip"
-* If none exists, create a placeholder.
-* @returns the HTML placeholder for tooltip
-*/
+ * Get the tooltip HTML placeholder by id selector "#vis-tooltip"
+ * If none exists, create a placeholder.
+ * @returns the HTML placeholder for tooltip
+ */
 export function getTooltipPlaceholder() {
   let tooltipPlaceholder;
 
@@ -21,8 +21,8 @@ export function getTooltipPlaceholder() {
 }
 
 /**
-* Bind tooltipData to the tooltip placeholder
-*/
+ * Bind tooltipData to the tooltip placeholder
+ */
 export function bindData(tooltipPlaceholder: Selection<Element | EnterElement | Document | Window, {}, HTMLElement, any>, tooltipData: TooltipData[]) {
   tooltipPlaceholder.selectAll('table').remove();
   const tooltipRows = tooltipPlaceholder.append('table').selectAll('.tooltip-row')
@@ -37,18 +37,18 @@ export function bindData(tooltipPlaceholder: Selection<Element | EnterElement | 
 }
 
 /**
-* Clear tooltip data
-*/
+ * Clear tooltip data
+ */
 export function clearData() {
   select('#vis-tooltip').selectAll('.tooltip-row').data([])
     .exit().remove();
 }
 
 /**
-* Update tooltip position
-* Default position is 10px right of and 10px below the cursor. This can be
-* overwritten by options.offset
-*/
+ * Update tooltip position
+ * Default position is 10px right of and 10px below the cursor. This can be
+ * overwritten by options.offset
+ */
 export function updatePosition(event: MouseEvent, options: Option) {
   // determine x and y offsets, defaults are 10px
   let offsetX = 10;
@@ -92,11 +92,11 @@ export function clearPosition() {
 }
 
 /**
-* Update tooltip color theme according to options.colorTheme
-*
-* If colorTheme === "dark", apply dark theme to tooltip.
-* Otherwise apply light color theme.
-*/
+ * Update tooltip color theme according to options.colorTheme
+ *
+ * If colorTheme === "dark", apply dark theme to tooltip.
+ * Otherwise apply light color theme.
+ */
 export function updateColorTheme(options: Option) {
   clearColorTheme();
 

--- a/src/tooltipDisplay.ts
+++ b/src/tooltipDisplay.ts
@@ -1,5 +1,5 @@
-import { EnterElement, select, Selection } from 'd3-selection';
-import { Option, TooltipData } from './options';
+import {EnterElement, select, Selection} from 'd3-selection';
+import {Option, TooltipData} from './options';
 
 /**
  * Get the tooltip HTML placeholder by id selector "#vis-tooltip"

--- a/vega-examples.html
+++ b/vega-examples.html
@@ -20,6 +20,8 @@
 
 <body>
   <h1>Vega Tooltip Examples</h1>
+  <a href="index.html" class="large">Back to overview</a>
+  
   <!-- Arc -->
   <div id="vis-arc" class="tooltip-example"></div>
 
@@ -35,7 +37,7 @@
   <!-- Placeholder for Tooltip -->
   <div id="vis-tooltip" class="vg-tooltip"></div>
 
-  <h1><a href="index.html">Back</a></h1>
+  <a href="index.html" class="large">Back to overview</a>
 
 </body>
 

--- a/vega-examples.html
+++ b/vega-examples.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+
+<head>
+  <title>Tooltip Examples</title>
+  <meta charset="utf-8">
+
+  <!-- Tooltip Library -->
+  <script src="https://d3js.org/d3.v4.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/vega/3.0.0-beta.31/vega.min.js"></script>
+
+  <script src="build/vega-tooltip.js"></script>
+  <link rel="stylesheet" type="text/css" href="build/vega-tooltip.css">
+
+  <!-- Example Page -->
+  <script type="text/javascript" src="vega-examples.js"></script>
+  <link rel="stylesheet" type="text/css" href="examples.css">
+
+</head>
+
+<body>
+  <h1>Vega Tooltip Examples</h1>
+  <!-- Arc -->
+  <div id="vis-arc" class="tooltip-example"></div>
+
+  <!-- Choropleth -->
+  <div id="vis-choropleth" class="tooltip-example"></div>
+
+  <!-- Force -->
+  <div id="vis-force" class="tooltip-example"></div>
+
+  <!-- Heatmap -->
+  <div id="vis-heatmap" class="tooltip-example"></div>
+
+  <!-- Placeholder for Tooltip -->
+  <div id="vis-tooltip" class="vg-tooltip"></div>
+
+</body>
+
+</html>

--- a/vega-examples.html
+++ b/vega-examples.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html>
 
 <head>
   <title>Tooltip Examples</title>
@@ -33,6 +34,8 @@
 
   <!-- Placeholder for Tooltip -->
   <div id="vis-tooltip" class="vg-tooltip"></div>
+
+  <h1><a href="index.html">Back</a></h1>
 
 </body>
 

--- a/vega-examples.js
+++ b/vega-examples.js
@@ -1,8 +1,8 @@
 "use strict";
 
-(function() {
+(function () {
   function addVgExample(path, id, options) {
-    d3.json(path, function(error, vgSpec) {
+    d3.json(path, function (error, vgSpec) {
       if (error) {
         return console.error(error);
       }
@@ -14,7 +14,7 @@
       vegaTooltip.vega(view, options);
     })
   }
-  
+
   // Vega Examples 
   // Arc
   addVgExample("exampleSpecs/arc.json", "#vis-arc");

--- a/vega-examples.js
+++ b/vega-examples.js
@@ -1,0 +1,67 @@
+"use strict";
+
+(function() {
+  function addVgExample(path, id, options) {
+    d3.json(path, function(error, vgSpec) {
+      if (error) {
+        return console.error(error);
+      }
+      var runtime = vega.parse(vgSpec);
+      var view = new vega.View(runtime)
+        .initialize(document.querySelector(id))
+        .hover()
+        .run();
+      vegaTooltip.vega(view, options);
+    })
+  }
+  
+  // Vega Examples 
+  // Arc
+  addVgExample("exampleSpecs/arc.json", "#vis-arc");
+
+  // Choropleth
+  var choroplethOpts = {
+    showAllFields: false,
+    fields: [
+      {
+        field: "unemp.id",
+        title: "County ID",
+        formatType: "string"
+      },
+      {
+        field: "unemp.rate",
+        title: "Unemployment Rate",
+        formatType: "number",
+        format: ".1%"
+      }
+    ]
+  }
+  addVgExample("exampleSpecs/choropleth.json", "#vis-choropleth", choroplethOpts);
+
+  // Force
+  var forceOpts = {
+    showAllFields: false,
+    fields: [
+      { field: "name" }
+    ]
+  }
+  addVgExample("exampleSpecs/force.json", "#vis-force", forceOpts);
+
+  // Heatmap
+  var heatmapOpts = {
+    showAllFields: false,
+    fields: [
+      {
+        field: "temp",
+        title: "temp(F)"
+      },
+      {
+        field: "date",
+        formatType: "time",
+        format: "%B %e"
+      },
+      { field: "hour" }
+    ]
+  }
+  addVgExample("exampleSpecs/heatmap.json", "#vis-heatmap", heatmapOpts);
+}());

--- a/vega-lite-examples.html
+++ b/vega-lite-examples.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html>
 
 <head>
   <title>Tooltip Examples</title>
@@ -51,6 +52,8 @@
 
   <!-- Overlay Area Chart -->
   <div id="vis-overlay-area" class="tooltip-example"></div>
+
+  <h1><a href="index.html">Back</a></h1>
 
 </body>
 

--- a/vega-lite-examples.html
+++ b/vega-lite-examples.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+
+<head>
+  <title>Tooltip Examples</title>
+  <meta charset="utf-8">
+
+  <!-- Tooltip Library -->
+  <script src="https://d3js.org/d3.v4.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/vega/3.0.0-beta.31/vega.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/vega-lite/2.0.0-beta.2/vega-lite.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/vega-embed/3.0.0-beta.14/vega-embed.min.js" charset="utf-8"></script>
+
+  <script src="build/vega-tooltip.js"></script>
+  <link rel="stylesheet" type="text/css" href="build/vega-tooltip.css">
+
+  <!-- Example Page -->
+  <script type="text/javascript" src="vega-lite-examples.js"></script>
+  <link rel="stylesheet" type="text/css" href="examples.css">
+
+</head>
+
+<body>
+  <h1>Vega-Lite Tooltip Examples</h1>
+
+  <!-- Scatter Plot -->
+  <div id="vis-scatter" class="tooltip-example"></div>
+
+  <!-- Bubble Plot -->
+  <div id="vis-bubble-multi-aggr" class="tooltip-example"></div>
+
+  <!-- Trellis Barley -->
+  <div id="vis-trellis-barley" class="tooltip-example"></div>
+
+  <!-- Scatter Binned -->
+  <div id="vis-scatter-binned" class="tooltip-example"></div>
+
+  <!-- Simple Bar Chart -->
+  <div id="vis-bar" class="tooltip-example"></div>
+
+  <!-- Stacked Bar Chart -->
+  <div id="vis-stacked-bar" class="tooltip-example"></div>
+
+  <!-- Layered Bar Chart -->
+  <div id="vis-layered-bar" class="tooltip-example"></div>
+
+  <!-- Color Line Chart -->
+  <div id="vis-color-line" class="tooltip-example"></div>
+
+  <!-- Overlay Line Chart -->
+  <div id="vis-overlay-line" class="tooltip-example"></div>
+
+  <!-- Overlay Area Chart -->
+  <div id="vis-overlay-area" class="tooltip-example"></div>
+
+</body>
+
+</html>

--- a/vega-lite-examples.html
+++ b/vega-lite-examples.html
@@ -22,6 +22,7 @@
 
 <body>
   <h1>Vega-Lite Tooltip Examples</h1>
+  <a href="index.html" class="large">Back to overview</a>
 
   <!-- Scatter Plot -->
   <div id="vis-scatter" class="tooltip-example"></div>
@@ -53,7 +54,7 @@
   <!-- Overlay Area Chart -->
   <div id="vis-overlay-area" class="tooltip-example"></div>
 
-  <h1><a href="index.html">Back</a></h1>
+  <a href="index.html" class="large">Back to overview</a>
 
 </body>
 

--- a/vega-lite-examples.js
+++ b/vega-lite-examples.js
@@ -1,16 +1,16 @@
 "use strict";
 
-(function() {
+(function () {
 
   function addVlExample(path, id, options) {
-    d3.json(path, function(error, vlSpec) {
+    d3.json(path, function (error, vlSpec) {
       if (error) {
         return console.warn(error);
       }
       var opt = {
         mode: "vega-lite"
       };
-      vega.embed(id, vlSpec, opt, function(error, result) {
+      vega.embed(id, vlSpec, opt, function (error, result) {
         if (error) {
           return console.error(error);
         }
@@ -77,8 +77,8 @@
   var binMovieOpts = {
     showAllFields: false,
     fields: [
-      {field: "Rotten_Tomatoes_Rating"},
-      {field: "IMDB_Rating"},
+      { field: "Rotten_Tomatoes_Rating" },
+      { field: "IMDB_Rating" },
     ]
   };
   addVlExample("exampleSpecs/scatter_binned.json", "#vis-scatter-binned", binMovieOpts);
@@ -102,7 +102,7 @@
       {
         field: "date",
         title: "date"
-      }, 
+      },
       {
         field: "series",
         title: "category"

--- a/vega-lite-examples.js
+++ b/vega-lite-examples.js
@@ -19,20 +19,6 @@
     });
   }
 
-  function addVgExample(path, id, options) {
-    d3.json(path, function(error, vgSpec) {
-      if (error) {
-        return console.error(error);
-      }
-      vega.embed(id, vgSpec, undefined, function(error, result) {
-        if (error) {
-          return console.error(error);
-        }
-        vegaTooltip.vega(result.view, options);
-      });
-    })
-  }
-
   /* Vega-Lite Examples */
   // Scatter Plot
   var scatterOpts = {
@@ -124,54 +110,4 @@
     ]
   }
   addVlExample("exampleSpecs/overlay_area_short.json", "#vis-overlay-area", overlayAreaOpts);
-  
-  // Vega Examples 
-  // Arc
-  addVgExample("exampleSpecs/arc.json", "#vis-arc");
-
-  // Choropleth
-  var choroplethOpts = {
-    showAllFields: false,
-    fields: [
-      {
-        field: "unemp.id",
-        title: "County ID",
-        formatType: "string"
-      },
-      {
-        field: "unemp.rate",
-        title: "Unemployment Rate",
-        formatType: "number",
-        format: ".1%"
-      }
-    ]
-  }
-  addVgExample("exampleSpecs/choropleth.json", "#vis-choropleth", choroplethOpts);
-
-  // Force
-  var forceOpts = {
-    showAllFields: false,
-    fields: [
-      { field: "name" }
-    ]
-  }
-  addVgExample("exampleSpecs/force.json", "#vis-force", forceOpts);
-
-  // Heatmap
-  var heatmapOpts = {
-    showAllFields: false,
-    fields: [
-      {
-        field: "temp",
-        title: "temp(F)"
-      },
-      {
-        field: "date",
-        formatType: "time",
-        format: "%B %e"
-      },
-      { field: "hour" }
-    ]
-  }
-  addVgExample("exampleSpecs/heatmap.json", "#vis-heatmap", heatmapOpts);
 }());


### PR DESCRIPTION
- split file into `parseOption.ts`, `formatFieldValue.ts`, `supplementField.ts` and `supplementField.ts` based on semantics.
- combine all the typings declaration into one `options.ts`