### PR TITLE
Edit package.json to include typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "vega-tooltip",
   "version": "0.4.0",
   "description": "A tooltip plugin for vega-lite and vega visualizations.",
-  "main": "build/src/index.js",
+  "main": "build/src/index",
+  "typings": "build/src/index",
   "repository": {
     "type": "git",
     "url": "https://github.com/vega/vega-tooltip.git"


### PR DESCRIPTION
- fix `Error TS7016: Could not find a declaration file for module 'vega-tooltip'` errors when running `npm run build:site` on vega-lite