### PR TITLE
Do not show tooltip for group marks

### DIFF
--- a/src/parseOption.ts
+++ b/src/parseOption.ts
@@ -8,7 +8,7 @@ import {FieldOption, Option, Scenegraph, ScenegraphData, SupplementedFieldOption
 // TODO: add marktype
 export function getTooltipData(item: Scenegraph, options: Option) {
   // ignore the data for group type that represents white space
-  if (item.mark.marktype === 'group' && item.mark.name === 'nested_main_group') {
+  if (item.mark.marktype === 'group') {
     return undefined;
   }
 

--- a/src/parseOption.ts
+++ b/src/parseOption.ts
@@ -7,7 +7,7 @@ import {FieldOption, Option, Scenegraph, ScenegraphData, SupplementedFieldOption
  */
 // TODO: add marktype
 export function getTooltipData(item: Scenegraph, options: Option) {
-  // ignore the data for group type that represents white space
+  // ignore data from group marks
   if (item.mark.marktype === 'group') {
     return undefined;
   }


### PR DESCRIPTION
Fix #123

`nested_main_group` was the old name for faceted plot, but this is no longer true for VL2.  I think we don't really need to check name as we should not show tooltip for group marks anyway.