### PR TITLE
Suppress warnings if the spec is composition

### DIFF
--- a/docs/APIs.md
+++ b/docs/APIs.md
@@ -77,4 +77,4 @@ Each member in the `fields` array can customize the format of a field. These cus
 
 | Method          | Parameter(s)   | Description     |
 | :-------------- |:--------------:| :-------------- |
-| .destroy        | none           | unregister tooltip event listners on `vgView` |
+| .destroy        | none           | unregister tooltip event listeners on `vgView` |

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ let tooltipActive = false;
  * options can specify whether to show all fields or to show only custom fields
  * It can also provide custom title and format for fields
  */
-export function vega(vgView: VgView, options: Option = {showAllFields: true}) {
+export function vega(vgView: VgView, options: Option = {showAllFields: true, isComposition: false}) {
   start(vgView, copyOptions(options));
 
   return {
@@ -28,9 +28,9 @@ export function vega(vgView: VgView, options: Option = {showAllFields: true}) {
   };
 }
 
-export function vegaLite(vgView: VgView, vlSpec: TopLevelExtendedSpec, options: Option = {showAllFields: true}) {
+export function vegaLite(vgView: VgView, vlSpec: TopLevelExtendedSpec, options: Option = {showAllFields: true, isComposition: false}) {
   options = supplementOptions(copyOptions(options), vlSpec);
-  start(vgView, options);
+  start(vgView, copyOptions(options));
 
   return {
     destroy: function () {

--- a/src/options.ts
+++ b/src/options.ts
@@ -11,6 +11,7 @@ export interface Option {
   onMove?(event: Event, item: object): void;
   onDisappear?(event: Event, item: object): void;
   colorTheme?: 'light' | 'dark';
+  isComposition?: boolean;
 }
 
 export interface FieldOption {

--- a/src/parseOption.ts
+++ b/src/parseOption.ts
@@ -59,7 +59,7 @@ export function prepareCustomFieldsData(itemData: ScenegraphData, options: Optio
     const title = fieldOption.title ? fieldOption.title : fieldOption.field;
 
     // get (raw) field value
-    const value = getValue(itemData, fieldOption.field);
+    const value = getValue(itemData, fieldOption.field, options.isComposition);
     if (value === undefined) {
       return undefined;
     }
@@ -82,7 +82,7 @@ export function prepareCustomFieldsData(itemData: ScenegraphData, options: Optio
  * @return the field value on success, undefined otherwise
  */
 // TODO(zening): Mute "Cannot find field" warnings for composite vis (issue #39)
-export function getValue(itemData: ScenegraphData, field: string) {
+export function getValue(itemData: ScenegraphData, field: string, isComposition: boolean) {
   let value: string | number | Date | ScenegraphData;
 
   const accessors: string[] = field.split('.');
@@ -103,7 +103,9 @@ export function getValue(itemData: ScenegraphData, field: string) {
   }
 
   if (value === undefined) {
-    console.warn('[Tooltip] Cannot find field ' + field + ' in data.');
+    if (!isComposition) {
+      console.warn('[Tooltip] Cannot find field ' + field + ' in data.');
+    }
     return undefined;
   } else {
     return value as string | number | Date;

--- a/src/supplementField.ts
+++ b/src/supplementField.ts
@@ -1,6 +1,6 @@
 import * as vl from 'vega-lite';
 import {FieldDef, MarkPropFieldDef, PositionFieldDef} from 'vega-lite/build/src/fielddef';
-import {TopLevelExtendedSpec} from 'vega-lite/build/src/spec';
+import {isConcatSpec, isFacetSpec, isLayerSpec, isRepeatSpec, normalize, TopLevelExtendedSpec} from 'vega-lite/build/src/spec';
 import {TEMPORAL} from 'vega-lite/build/src/type';
 import {FieldOption, Option, SupplementedFieldOption} from './options';
 
@@ -27,6 +27,7 @@ const formatTypeMap: { [type: string]: 'number' | 'time' } = {
 export function supplementOptions(options: Option, vlSpec: TopLevelExtendedSpec) {
   // fields to be supplemented by vlSpec
   const supplementedFields: FieldOption[] = [];
+  vlSpec = normalize(vlSpec, {});
 
   // if showAllFields is true or undefined, supplement all fields in vlSpec
   if (options.showAllFields !== false) {
@@ -51,6 +52,10 @@ export function supplementOptions(options: Option, vlSpec: TopLevelExtendedSpec)
         supplementedFields.push(supplementedFieldOption);
       });
     }
+  }
+
+  if (isComposition(vlSpec)) {
+    options.isComposition = true;
   }
 
   options.fields = supplementedFields;
@@ -261,4 +266,12 @@ function isPositionFieldDef(fd: FieldDef<any>): fd is PositionFieldDef<any> {
 function isMarkPropFieldDef(fd: FieldDef<any>): fd is MarkPropFieldDef<any> {
   // the fieldDef may still be a MarkPropFieldDef even if it doesn't have a legend
   return 'legend' in fd;
+}
+
+/**
+ * Returns true if the spec is composition (one of concat, facet, layer or repeat), false otherwise
+ * @param vlSpec Vega-lite spec
+ */
+function isComposition(vlSpec: TopLevelExtendedSpec) {
+  return isConcatSpec(vlSpec) || isFacetSpec(vlSpec) || isLayerSpec(vlSpec) || isRepeatSpec(vlSpec);
 }


### PR DESCRIPTION
- Stop-gap fix for #108 and #39 by suppressing the warnings on missing fields in composite spec