### PR TITLE
Handle exceptions, warnings, and fix 0-value handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,39 +14,18 @@ let tooltipActive = false;
  * It can also provide custom title and format for fields
  */
 export function vega(vgView: VgView, options: Option = {showAllFields: true, isComposition: false}) {
-  start(vgView, copyOptions(options));
-
-  return {
-    destroy: function () {
-      // remove event listeners
-      vgView.removeEventListener('mouseover.tooltipInit');
-      vgView.removeEventListener('mousemove.tooltipUpdate');
-      vgView.removeEventListener('mouseout.tooltipRemove');
-
-      cancelPromise(); // clear tooltip promise
-    }
-  };
+  return start(vgView, copyOptions(options));
 }
 
 export function vegaLite(vgView: VgView, vlSpec: TopLevelSpec, options: Option = {showAllFields: true, isComposition: false}) {
   options = supplementOptions(vgView.warn.bind(vgView), copyOptions(options), vlSpec);
-  start(vgView, copyOptions(options));
-
-  return {
-    destroy: function () {
-      // remove event listeners
-      vgView.removeEventListener('mouseover.tooltipInit');
-      vgView.removeEventListener('mousemove.tooltipUpdate');
-      vgView.removeEventListener('mouseout.tooltipRemove');
-
-      cancelPromise(); // clear tooltip promise
-    }
-  };
+  return start(vgView, options);
 }
 
 function start(vgView: VgView, options: Option) {
   // TODO: ideally many of the existing functions should be moved to a proper class with this var as a member field
   const warn = vgView.warn.bind(vgView);
+  const tooltipId = options && options.tooltipElemId || 'vis-tooltip';
 
   // initialize tooltip with item data and options on mouse over
   vgView.addEventListener('mouseover.tooltipInit', function (event: MouseEvent, item: Scenegraph) {
@@ -57,7 +36,7 @@ function start(vgView: VgView, options: Option) {
       // make a new promise with time delay for tooltip
       tooltipPromise = window.setTimeout(function () {
         try {
-          init(warn, event, item, options);
+          init(warn, tooltipId, event, item, options);
         } catch (err) {
           vgView.error(err);
         }
@@ -69,7 +48,7 @@ function start(vgView: VgView, options: Option) {
   // (important for large marks e.g. bars)
   vgView.addEventListener('mousemove.tooltipUpdate', function (event: MouseEvent, item: Scenegraph) {
     if (shouldShowTooltip(item) && tooltipActive) {
-      update(event, item, options);
+      update(event, item, options, tooltipId);
     }
   });
 
@@ -79,10 +58,22 @@ function start(vgView: VgView, options: Option) {
       cancelPromise();
 
       if (tooltipActive) {
-        clear(event, item, options);
+        clear(event, item, options, tooltipId);
       }
     }
   });
+
+  return {
+    destroy: function () {
+      // remove event listeners
+      vgView.removeEventListener('mouseover.tooltipInit');
+      vgView.removeEventListener('mousemove.tooltipUpdate');
+      vgView.removeEventListener('mouseout.tooltipRemove');
+
+      cancelPromise(); // clear tooltip promise
+    }
+  };
+
 }
 
 /* Cancel tooltip promise */
@@ -95,9 +86,9 @@ function cancelPromise() {
 }
 
 /* Initialize tooltip with data */
-function init(warn, event: MouseEvent, item: Scenegraph, options: Option): void {
+function init(warn, tooltipId: string, event: MouseEvent, item: Scenegraph, options: Option): void {
   // get tooltip HTML placeholder
-  const tooltipPlaceholder = getTooltipPlaceholder();
+  const tooltipPlaceholder = getTooltipPlaceholder(tooltipId);
 
   // prepare data for tooltip
   const tooltipData = getTooltipData(warn, item, options);
@@ -108,9 +99,9 @@ function init(warn, event: MouseEvent, item: Scenegraph, options: Option): void 
   // bind data to tooltip HTML placeholder
   bindData(tooltipPlaceholder, tooltipData);
 
-  updatePosition(event, options);
-  updateColorTheme(options);
-  select('#vis-tooltip').style('visibility', 'visible');
+  updatePosition(event, options, tooltipId);
+  updateColorTheme(options, tooltipId);
+  select('#' + tooltipId).style('visibility', 'visible');
   tooltipActive = true;
 
   // invoke user-provided callback
@@ -120,11 +111,11 @@ function init(warn, event: MouseEvent, item: Scenegraph, options: Option): void 
 }
 
 /* Update tooltip position on mousemove */
-function update(event: MouseEvent, item: Scenegraph, options: Option): void {
+function update(event: MouseEvent, item: Scenegraph, options: Option, tooltipId): void {
   if (!shouldShowTooltip(item)) {
     return undefined;
   }
-  updatePosition(event, options);
+  updatePosition(event, options, tooltipId);
 
   // invoke user-provided callback
   if (options.onMove) {
@@ -133,18 +124,18 @@ function update(event: MouseEvent, item: Scenegraph, options: Option): void {
 }
 
 /* Clear tooltip */
-function clear(event: MouseEvent, item: Scenegraph, options: Option): void {
+function clear(event: MouseEvent, item: Scenegraph, options: Option, tooltipId: string): void {
   if (!shouldShowTooltip(item)) {
     return undefined;
   }
   // visibility hidden instead of display none
   // because we need computed tooltip width and height to best position it
-  select('#vis-tooltip').style('visibility', 'hidden');
+  select('#' + tooltipId).style('visibility', 'hidden');
 
   tooltipActive = false;
-  clearData();
-  clearColorTheme();
-  clearPosition();
+  clearData(tooltipId);
+  clearColorTheme(tooltipId);
+  clearPosition(tooltipId);
 
   // invoke user-provided callback
   if (options.onDisappear) {

--- a/src/options.ts
+++ b/src/options.ts
@@ -15,6 +15,7 @@ export interface Option {
   colorTheme?: 'light' | 'dark';
   isComposition?: boolean;
   sort?: 'title' | 'value' | SortCallback;
+  tooltipElemId?: 'vis-tooltip';
 }
 
 export type TitleAccessor = (item: ScenegraphData) => string;

--- a/src/parseOption.ts
+++ b/src/parseOption.ts
@@ -123,13 +123,13 @@ export function getValue(itemData: ScenegraphData, field: string, isComposition:
   // get the first accessor and remove it from the array
   const firstAccessor: string = accessors[0];
   accessors.shift();
-  if (itemData[firstAccessor]) {
+  if (itemData[firstAccessor] !== undefined) {
     value = itemData[firstAccessor];
 
     // if we still have accessors, use them to get the value
     accessors.forEach(function (a) {
       value = value as ScenegraphData;
-      if (value[a]) {
+      if (value[a] !== undefined) {
         value = value[a];
       }
     });

--- a/src/parseOption.ts
+++ b/src/parseOption.ts
@@ -7,7 +7,7 @@ import {FieldOption, Option, Scenegraph, ScenegraphData, SupplementedFieldOption
  * @return An array of tooltip data [{ title: ..., value: ...}]
  */
 // TODO: add marktype
-export function getTooltipData(item: Scenegraph, options: Option) {
+export function getTooltipData(warn, item: Scenegraph, options: Option) {
   // ignore data from group marks
   if (item.mark.marktype === 'group') {
     return undefined;
@@ -37,9 +37,9 @@ export function getTooltipData(item: Scenegraph, options: Option) {
   // TODO(zening): use Vega-Lite layering to support tooltip on line and area charts (#1)
   dropFieldsForLineArea(item.mark.marktype, itemData);
   if (options.showAllFields === true) {
-    tooltipData = prepareAllFieldsData(itemData, options);
+    tooltipData = prepareAllFieldsData(warn, itemData, options);
   } else {
-    tooltipData = prepareCustomFieldsData(itemData, options);
+    tooltipData = prepareCustomFieldsData(warn, itemData, options);
   }
 
   if (options.sort) {
@@ -60,12 +60,17 @@ export function getTooltipData(item: Scenegraph, options: Option) {
  * Prepare custom fields data for tooltip. This function formats
  * field titles and values and returns an array of formatted fields.
  *
+ * @param {function} warn
  * @param {time.map} itemData - a map of item.datum
  * @param {Object} options - user-provided options
  * @return An array of formatted fields specified by options [{ title: ..., value: ...}]
  */
-export function prepareCustomFieldsData(itemData: ScenegraphData, options: Option = {}) {
+export function prepareCustomFieldsData(warn, itemData: ScenegraphData, options: Option = {}) {
   const tooltipData: TooltipData[] = [];
+
+  if (!options.fields || !options.fields.forEach) {
+    return tooltipData;
+  }
 
   options.fields.forEach(function (fieldOption) {
     const titleStr = isString(fieldOption.title) ? fieldOption.title : undefined;
@@ -80,7 +85,7 @@ export function prepareCustomFieldsData(itemData: ScenegraphData, options: Optio
     // get (raw) field value
     const value =
       (fieldOption.valueAccessor && fieldOption.valueAccessor(itemData)) ||
-      getValue(itemData, fieldOption.field, options.isComposition);
+      getValue(itemData, fieldOption.field, options.isComposition, warn);
     if (value === undefined) {
       return undefined;
     }
@@ -105,10 +110,12 @@ export function prepareCustomFieldsData(itemData: ScenegraphData, options: Optio
  * @param {time.map} itemData - a map of item.datum
  * @param {string} field - the name of the field. It can contain "." to specify
  * that the field is not a direct child of item.datum
+ * @param isComposition
+ * @param {function} warn
  * @return the field value on success, undefined otherwise
  */
 // TODO(zening): Mute "Cannot find field" warnings for composite vis (issue #39)
-export function getValue(itemData: ScenegraphData, field: string, isComposition: boolean) {
+export function getValue(itemData: ScenegraphData, field: string, isComposition: boolean, warn) {
   let value: string | number | Date | ScenegraphData;
 
   const accessors: string[] = field.split('.');
@@ -130,7 +137,7 @@ export function getValue(itemData: ScenegraphData, field: string, isComposition:
 
   if (value === undefined) {
     if (!isComposition) {
-      console.warn('[Tooltip] Cannot find field ' + field + ' in data.');
+      warn('[Tooltip] Cannot find field ' + field + ' in data.');
     }
     return undefined;
   } else {
@@ -143,6 +150,7 @@ export function getValue(itemData: ScenegraphData, field: string, isComposition:
  * Prepare data for all fields in itemData for tooltip. This function
  * formats field titles and values and returns an array of formatted fields.
  *
+ * @param {function} warn
  * @param {time.map} itemData - a map of item.datum
  * @param {Object} options - user-provided options
  * @return All fields in itemData, formatted, in the form of an array: [{ title: ..., value: ...}]
@@ -151,7 +159,7 @@ export function getValue(itemData: ScenegraphData, field: string, isComposition:
  * It will not try to parse value if it is an object. If value is an object, please
  * use prepareCustomFieldsData() instead.
  */
-export function prepareAllFieldsData(itemData: ScenegraphData, options: Option = {}) {
+export function prepareAllFieldsData(warn, itemData: ScenegraphData, options: Option = {}) {
   const tooltipData: TooltipData[] = [];
 
   // here, fieldOptions still provides format

--- a/src/supplementField.ts
+++ b/src/supplementField.ts
@@ -16,6 +16,7 @@ const formatTypeMap: { [type: string]: 'number' | 'time' } = {
 /**
  * (Vega-Lite only) Supplement options with vlSpec
  *
+ * @param {function} warn
  * @param options - user-provided options
  * @param vlSpec - vega-lite spec
  * @return the vlSpec-supplemented options object
@@ -25,7 +26,7 @@ const formatTypeMap: { [type: string]: 'number' | 'time' } = {
  * if options.showAllFields is false, vlSpec will only supplement existing fields
  * in options.fields
  */
-export function supplementOptions(options: Option, vlSpec: TopLevelSpec) {
+export function supplementOptions(warn, options: Option, vlSpec: TopLevelSpec) {
   // fields to be supplemented by vlSpec
   const supplementedFields: FieldOption[] = [];
   const normalizedVlSpec = normalize(vlSpec, {});
@@ -37,7 +38,7 @@ export function supplementOptions(options: Option, vlSpec: TopLevelSpec) {
       const fieldOption = getFieldOption(options.fields, fieldDef);
 
       // supplement the fieldOption with fieldDef and config
-      const supplementedFieldOption = supplementFieldOption(fieldOption, fieldDef, vlSpec.config, normalizedVlSpec);
+      const supplementedFieldOption = supplementFieldOption(warn, fieldOption, fieldDef, vlSpec.config, normalizedVlSpec);
 
       supplementedFields.push(supplementedFieldOption);
     });
@@ -48,7 +49,7 @@ export function supplementOptions(options: Option, vlSpec: TopLevelSpec) {
         const fieldDef = getFieldDef(vl.spec.fieldDefs(vlSpec), fieldOption);
 
         // supplement the fieldOption with fieldDef and config
-        const supplementedFieldOption = supplementFieldOption(fieldOption, fieldDef, vlSpec.config, normalizedVlSpec);
+        const supplementedFieldOption = supplementFieldOption(warn, fieldOption, fieldDef, vlSpec.config, normalizedVlSpec);
 
         supplementedFields.push(supplementedFieldOption);
       });
@@ -149,10 +150,10 @@ export function getFieldDef(fieldDefs: FieldDef<any>[], fieldOption: FieldOption
  * config (and its members timeFormat, numberFormat and countTitle) can be undefined.
  * @return the supplemented fieldOption, or undefined on error
  */
-export function supplementFieldOption(fieldOption: FieldOption, fieldDef: FieldDef<any>, config: Config = {}, vlSpec: NormalizedSpec) {
+export function supplementFieldOption(warn, fieldOption: FieldOption, fieldDef: FieldDef<any>, config: Config = {}, vlSpec: NormalizedSpec) {
   // at least one of fieldOption and fieldDef should exist
   if (!fieldOption && !fieldDef) {
-    console.error('[Tooltip] Cannot supplement a field when field and fieldDef are both empty.');
+    warn('[Tooltip] Cannot supplement a field when field and fieldDef are both empty.');
     return undefined;
   }
 

--- a/src/tooltipDisplay.ts
+++ b/src/tooltipDisplay.ts
@@ -6,12 +6,12 @@ import {Option, TooltipData} from './options';
  * If none exists, create a placeholder.
  * @returns the HTML placeholder for tooltip
  */
-export function getTooltipPlaceholder() {
-  let tooltipPlaceholder = select('#vis-tooltip');
+export function getTooltipPlaceholder(tooltipId: string) {
+  let tooltipPlaceholder = select('#' + tooltipId);
 
   if (tooltipPlaceholder.empty()) {
     tooltipPlaceholder = select('body').append('div')
-      .attr('id', 'vis-tooltip')
+      .attr('id', tooltipId)
       .attr('class', 'vg-tooltip');
   }
 
@@ -46,8 +46,8 @@ export function bindData(tooltipPlaceholder: Selection<Element | EnterElement | 
 /**
  * Clear tooltip data
  */
-export function clearData() {
-  select('#vis-tooltip').selectAll('.tooltip-row').data([])
+export function clearData(tooltipId: string) {
+  select('#' + tooltipId).selectAll('.tooltip-row').data([])
     .exit().remove();
 }
 
@@ -56,7 +56,7 @@ export function clearData() {
  * Default position is 10px right of and 10px below the cursor. This can be
  * overwritten by options.offset
  */
-export function updatePosition(event: MouseEvent, options: Option) {
+export function updatePosition(event: MouseEvent, options: Option, tooltipId: string) {
   // determine x and y offsets, defaults are 10px
   let offsetX = 10;
   let offsetY = 10;
@@ -68,7 +68,7 @@ export function updatePosition(event: MouseEvent, options: Option) {
   }
 
   // TODO: use the correct time type
-  select('#vis-tooltip')
+  select('#' + tooltipId)
     .style('top', function (this: HTMLElement) {
       // by default: put tooltip 10px below cursor
       // if tooltip is close to the bottom of the window, put tooltip 10px above cursor
@@ -92,8 +92,8 @@ export function updatePosition(event: MouseEvent, options: Option) {
 }
 
 /* Clear tooltip position */
-export function clearPosition() {
-  select('#vis-tooltip')
+export function clearPosition(tooltipId: string) {
+  select('#' + tooltipId)
     .style('top', '-9999px')
     .style('left', '-9999px');
 }
@@ -104,17 +104,17 @@ export function clearPosition() {
  * If colorTheme === "dark", apply dark theme to tooltip.
  * Otherwise apply light color theme.
  */
-export function updateColorTheme(options: Option) {
-  clearColorTheme();
+export function updateColorTheme(options: Option, tooltipId: string) {
+  clearColorTheme(tooltipId);
 
   if (options && options.colorTheme === 'dark') {
-    select('#vis-tooltip').classed('dark-theme', true);
+    select('#' + tooltipId).classed('dark-theme', true);
   } else {
-    select('#vis-tooltip').classed('light-theme', true);
+    select('#' + tooltipId).classed('light-theme', true);
   }
 }
 
 /* Clear color themes */
-export function clearColorTheme() {
-  select('#vis-tooltip').classed('dark-theme light-theme', false);
+export function clearColorTheme(tooltipId: string) {
+  select('#' + tooltipId).classed('dark-theme light-theme', false);
 }


### PR DESCRIPTION
Some large systems (e.g. Kibana) fully crash in case something throws an unhandled exception. This patch makes all exceptions pass to `vega.view.error()` method. Additionally, this patch makes warnings go to `.warn` instead of the console. Lastly, there was a bug with "falsey" values (like 0, false, '') - showing a warning instead of the proper value - fixed.