### PR TITLE
hide tooltip on empty string

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -175,6 +175,8 @@ export class Handler {
    * The handler function.
    */
   private handler(handler: any, event: MouseEvent, item: any, value: any) {
+    // console.log(handler, event, item, value);
+
     // hide tooltip for any of these. Undefined included for backward compatibility
     if (value === null || value === '' || value === undefined) {
       this.el.classList.remove('visible', `${this.options.theme}-theme`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -175,9 +175,8 @@ export class Handler {
    * The handler function.
    */
   private handler(handler: any, event: MouseEvent, item: any, value: any) {
-    // console.log(handler, event, item, value);
-
-    if (value === null) {
+    // hide tooltip for any of these. Undefined included for backward compatibility
+    if (value === null || value === '' || value === undefined) {
       this.el.classList.remove('visible', `${this.options.theme}-theme`);
       return;
     }


### PR DESCRIPTION
Empty string shows an empty box, even though the expectation is that it's not shown.