### PR TITLE
Append `toString` to `defaultStyle`

### DIFF
--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -67,5 +67,5 @@ export function createDefaultStyle(id: string): string {
     throw new Error('Invalid HTML ID');
   }
 
-  return defaultStyle.replace(EL_ID, id);
+  return defaultStyle.toString().replace(EL_ID, id);
 }


### PR DESCRIPTION
Editor with `vega-tooltip v0.10.1` error fix.