### PR TITLE
chore: sync prerelease branch version with stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vega-tooltip",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "A tooltip plugin for Vega-Lite and Vega visualizations.",
   "keywords": [
     "vega-lite",


### PR DESCRIPTION
## Motivation

- Currently, merging `latest` -> `stable` bumps the library version for `stable`, but the `prerelease` branch keeps its old version number.
- The only impact of this for users is they might be confused if they download the `latest` tag, and see the package.json is older than they expect.

## Future-follow-up

- We won't have to manually do this step after resolving https://github.com/intuit/auto/issues/2047