### PR TITLE
chore: remove `NODE_AUTH_TOKEN`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,5 +32,4 @@ jobs:
         run: npm run release
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.28.1--canary.687.3e8dda7.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vega-tooltip@0.28.1--canary.687.3e8dda7.0
  # or 
  yarn add vega-tooltip@0.28.1--canary.687.3e8dda7.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
