### PR TITLE
fix: update tooltip positioning for CSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ vegaEmbed("#vis", spec, {tooltip: {theme: 'dark'}})
   .catch(console.error);
 ```
 
-If you want to ue a different version of the tooltip handler, you can override the default handler with the handler from Vega Tooltip (and you need to install it separately).
+If you want to use a different version of the tooltip handler, you can override the default handler with the handler from Vega Tooltip (and you need to install it separately).
 
 ```js
 var handler = new vegaTooltip.Handler();

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -86,7 +86,6 @@ export class Handler {
       this.options.offsetY
     );
 
-    // position the tooltip
     this.el.style.top = `${y}px`;
     this.el.style.left = `${x}px`;
   }

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -86,6 +86,8 @@ export class Handler {
       this.options.offsetY
     );
 
-    this.el.setAttribute('style', `top: ${y}px; left: ${x}px`);
+    // position the tooltip
+    this.el.style.top = `${y}px`;
+    this.el.style.left = `${x}px`;
   }
 }


### PR DESCRIPTION
For sites with Content Security Policies that do not feature the `unsafe-inline` specification, it seems the more preferable approach for tooltip positioning is using the CSS Object Model method `.style`.

Currently, vega-tooltip uses `setAttribute` to adjust the tooltip positioning (top & left) at the same time - [here](https://github.com/vega/vega-tooltip/blob/7e2b7c0b4b75edabbc3afb292e05555ae1d7adef/src/Handler.ts#L89). This invokes the HTML parser and CSP inline checks are triggered, blocking the operation. When the tooltip positioning is directly adjusted via `.style.top` & `.style.left`, the operations successfully comply with a CSP directive of `style-src: self`.

Some discussion/context [here](https://github.com/w3c/webappsec-csp/issues/212)
