### PR TITLE
feat: remove limit on image size in tooltips

### DIFF
--- a/vega-tooltip.scss
+++ b/vega-tooltip.scss
@@ -18,11 +18,6 @@
     font-size: 13px;
   }
 
-  img {
-    max-width: 200px;
-    max-height: 200px;
-  }
-
   table {
     border-spacing: 0;
 


### PR DESCRIPTION
To resolve #739 as discussed there