### PR TITLE
feat: anchor tooltip to mark

### DIFF
--- a/examples/examples.css
+++ b/examples/examples.css
@@ -28,3 +28,7 @@ body {
   top: 1em;
   right: 1em;
 }
+
+.options {
+  margin-top: 24px;
+}

--- a/examples/vega-examples.html
+++ b/examples/vega-examples.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <title>Tooltip Examples</title>
@@ -35,12 +35,12 @@
         await vegaEmbed(id, vgSpec, { tooltip: handler.call }).catch(console.error);
       }
 
-      addVgExample("specs/images.json", "#vis-images");
-      addVgExample("specs/arc.json", "#vis-arc");
-      addVgExample("specs/choropleth.json", "#vis-choropleth");
+      addVgExample("specs/images.json", "#vis-images", { anchor: "item", position: "right" });
+      addVgExample("specs/arc.json", "#vis-arc", { anchor: "item", position: "right" });
+      addVgExample("specs/choropleth.json", "#vis-choropleth", { anchor: "item", position: "right" });
       addVgExample("specs/force.json", "#vis-force", { theme: "dark" });
-      addVgExample("specs/heatmap.json", "#vis-heatmap");
-      addVgExample("specs/voronoi.json", "#vis-voronoi");
+      addVgExample("specs/heatmap.json", "#vis-heatmap", { anchor: "item" });
+      addVgExample("specs/voronoi.json", "#vis-voronoi", { anchor: "item" });
     </script>
   </body>
 </html>

--- a/examples/vega-examples.html
+++ b/examples/vega-examples.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
   <head>
     <title>Tooltip Examples</title>
@@ -35,17 +35,12 @@
         await vegaEmbed(id, vgSpec, { tooltip: handler.call }).catch(console.error);
       }
 
-      addVgExample("specs/images.json", "#vis-images", {
-        anchor: "mark",
-        position: ["right", "top", "left", "bottom"],
-      });
-      addVgExample("specs/arc.json", "#vis-arc", { anchor: "mark", position: "right" });
-      addVgExample("specs/choropleth.json", "#vis-choropleth", { anchor: "mark", position: "right" });
+      addVgExample("specs/images.json", "#vis-images");
+      addVgExample("specs/arc.json", "#vis-arc");
+      addVgExample("specs/choropleth.json", "#vis-choropleth");
       addVgExample("specs/force.json", "#vis-force", { theme: "dark" });
-      addVgExample("specs/heatmap.json", "#vis-heatmap", {
-        anchor: "mark",
-      });
-      addVgExample("specs/voronoi.json", "#vis-voronoi", { anchor: "mark" });
+      addVgExample("specs/heatmap.json", "#vis-heatmap");
+      addVgExample("specs/voronoi.json", "#vis-voronoi");
     </script>
   </body>
 </html>

--- a/examples/vega-examples.html
+++ b/examples/vega-examples.html
@@ -19,7 +19,7 @@
     <div class="options">
       <div>
         <span>anchor:</span>
-        <label> <input type="radio" name="anchor" value="light" id="anchor-cursor" checked /> cursor </label>
+        <label> <input type="radio" name="anchor" value="cursor" id="anchor-cursor" checked /> cursor </label>
         <label> <input type="radio" name="anchor" value="mark" id="anchor-mark" /> mark </label>
       </div>
     </div>

--- a/examples/vega-examples.html
+++ b/examples/vega-examples.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <title>Tooltip Examples</title>
@@ -16,6 +16,13 @@
   <body>
     <h1>Vega Tooltip Examples</h1>
     <a href="index.html" class="large">Back to overview</a>
+    <div class="options">
+      <div>
+        <span>anchor:</span>
+        <label> <input type="radio" name="anchor" value="light" id="anchor-cursor" checked /> cursor </label>
+        <label> <input type="radio" name="anchor" value="mark" id="anchor-mark" /> mark </label>
+      </div>
+    </div>
     <div>
       <div id="vis-images" class="tooltip-example"></div>
       <div id="vis-arc" class="tooltip-example"></div>
@@ -35,12 +42,23 @@
         await vegaEmbed(id, vgSpec, { tooltip: handler.call }).catch(console.error);
       }
 
-      addVgExample("specs/images.json", "#vis-images");
-      addVgExample("specs/arc.json", "#vis-arc");
-      addVgExample("specs/choropleth.json", "#vis-choropleth");
-      addVgExample("specs/force.json", "#vis-force", { theme: "dark" });
-      addVgExample("specs/heatmap.json", "#vis-heatmap");
-      addVgExample("specs/voronoi.json", "#vis-voronoi");
+      function renderCharts() {
+        const anchor = document.getElementById("anchor-cursor").checked ? "cursor" : "mark";
+
+        addVgExample("specs/images.json", "#vis-images", { anchor });
+        addVgExample("specs/arc.json", "#vis-arc", { anchor });
+        addVgExample("specs/choropleth.json", "#vis-choropleth", { anchor });
+        addVgExample("specs/force.json", "#vis-force", { anchor, theme: "dark" });
+        addVgExample("specs/heatmap.json", "#vis-heatmap", { anchor });
+        addVgExample("specs/voronoi.json", "#vis-voronoi", { anchor });
+      }
+
+      // Initial render
+      renderCharts();
+
+      // Re-render charts when the checkbox is clicked
+      document.getElementById("anchor-cursor").addEventListener("change", renderCharts);
+      document.getElementById("anchor-mark").addEventListener("change", renderCharts);
     </script>
   </body>
 </html>

--- a/examples/vega-examples.html
+++ b/examples/vega-examples.html
@@ -35,12 +35,17 @@
         await vegaEmbed(id, vgSpec, { tooltip: handler.call }).catch(console.error);
       }
 
-      addVgExample("specs/images.json", "#vis-images", { anchor: "item", position: "right" });
-      addVgExample("specs/arc.json", "#vis-arc", { anchor: "item", position: "right" });
-      addVgExample("specs/choropleth.json", "#vis-choropleth", { anchor: "item", position: "right" });
+      addVgExample("specs/images.json", "#vis-images", {
+        anchor: "mark",
+        position: ["right", "top", "left", "bottom"],
+      });
+      addVgExample("specs/arc.json", "#vis-arc", { anchor: "mark", position: "right" });
+      addVgExample("specs/choropleth.json", "#vis-choropleth", { anchor: "mark", position: "right" });
       addVgExample("specs/force.json", "#vis-force", { theme: "dark" });
-      addVgExample("specs/heatmap.json", "#vis-heatmap", { anchor: "item" });
-      addVgExample("specs/voronoi.json", "#vis-voronoi", { anchor: "item" });
+      addVgExample("specs/heatmap.json", "#vis-heatmap", {
+        anchor: "mark",
+      });
+      addVgExample("specs/voronoi.json", "#vis-voronoi", { anchor: "mark" });
     </script>
   </body>
 </html>

--- a/examples/vega-lite-examples.html
+++ b/examples/vega-lite-examples.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <title>Tooltip Examples</title>
@@ -17,6 +17,13 @@
   <body>
     <h1>Vega-Lite Tooltip Examples</h1>
     <a href="index.html" class="large">Back to overview</a>
+    <div class="options">
+      <div>
+        <span>anchor:</span>
+        <label> <input type="radio" name="anchor" value="light" id="anchor-cursor" checked /> cursor </label>
+        <label> <input type="radio" name="anchor" value="mark" id="anchor-mark" /> mark </label>
+      </div>
+    </div>
     <div>
       <div id="vis-histogram" class="tooltip-example"></div>
       <div id="vis-scatter" class="tooltip-example"></div>
@@ -50,19 +57,31 @@
         });
       }
 
-      addVlExample("specs/histogram.json", "#vis-histogram");
-      addVlExample("specs/scatter.json", "#vis-scatter");
-      addVlExample("specs/bubble_multiple_aggregation.json", "#vis-bubble-multi-aggr");
-      addVlExample("specs/trellis_barley.json", "#vis-trellis-barley");
-      addVlExample("specs/scatter_binned.json", "#vis-scatter-binned");
-      addVlExample("specs/bar.json", "#vis-bar");
-      addVlExample("specs/stacked_bar_weather.json", "#vis-stacked-bar");
-      addVlExample("specs/bar_layered_transparent.json", "#vis-layered-bar");
-      addVlExample("specs/line_color.json", "#vis-color-line");
-      addVlExample("specs/overlay_area_short.json", "#vis-overlay-area");
-      addVlExample("specs/bar_format_tooltip.json", "#vis-bar-format-tooltip", {
-        formatTooltip: (value, sanitize) => `The value of ${sanitize(value.a)} is ${sanitize(value.b)}`,
-      });
+      function renderCharts() {
+        const anchor = document.getElementById("anchor-cursor").checked ? "cursor" : "mark";
+
+        addVlExample("specs/histogram.json", "#vis-histogram", { anchor });
+        addVlExample("specs/scatter.json", "#vis-scatter", { anchor });
+        addVlExample("specs/bubble_multiple_aggregation.json", "#vis-bubble-multi-aggr", { anchor });
+        addVlExample("specs/trellis_barley.json", "#vis-trellis-barley", { anchor });
+        addVlExample("specs/scatter_binned.json", "#vis-scatter-binned", { anchor });
+        addVlExample("specs/bar.json", "#vis-bar", { anchor });
+        addVlExample("specs/stacked_bar_weather.json", "#vis-stacked-bar", { anchor });
+        addVlExample("specs/bar_layered_transparent.json", "#vis-layered-bar", { anchor });
+        addVlExample("specs/line_color.json", "#vis-color-line", { anchor });
+        addVlExample("specs/overlay_area_short.json", "#vis-overlay-area", { anchor });
+        addVlExample("specs/bar_format_tooltip.json", "#vis-bar-format-tooltip", {
+          anchor,
+          formatTooltip: (value, sanitize) => `The value of ${sanitize(value.a)} is ${sanitize(value.b)}`,
+        });
+      }
+
+      // Initial render
+      renderCharts();
+
+      // Re-render charts when the checkbox is clicked
+      document.getElementById("anchor-cursor").addEventListener("change", renderCharts);
+      document.getElementById("anchor-mark").addEventListener("change", renderCharts);
     </script>
   </body>
 </html>

--- a/examples/vega-lite-examples.html
+++ b/examples/vega-lite-examples.html
@@ -50,16 +50,16 @@
         });
       }
 
-      addVlExample("specs/histogram.json", "#vis-histogram", { anchor: "item" });
-      addVlExample("specs/scatter.json", "#vis-scatter", { anchor: "item" });
-      addVlExample("specs/bubble_multiple_aggregation.json", "#vis-bubble-multi-aggr", { anchor: "item" });
-      addVlExample("specs/trellis_barley.json", "#vis-trellis-barley", { anchor: "item" });
-      addVlExample("specs/scatter_binned.json", "#vis-scatter-binned", { anchor: "item" });
-      addVlExample("specs/bar.json", "#vis-bar", { anchor: "item" });
-      addVlExample("specs/stacked_bar_weather.json", "#vis-stacked-bar", { anchor: "item" });
-      addVlExample("specs/bar_layered_transparent.json", "#vis-layered-bar", { anchor: "item" });
-      addVlExample("specs/line_color.json", "#vis-color-line", { anchor: "item" });
-      addVlExample("specs/overlay_area_short.json", "#vis-overlay-area", { anchor: "item" });
+      addVlExample("specs/histogram.json", "#vis-histogram");
+      addVlExample("specs/scatter.json", "#vis-scatter");
+      addVlExample("specs/bubble_multiple_aggregation.json", "#vis-bubble-multi-aggr");
+      addVlExample("specs/trellis_barley.json", "#vis-trellis-barley");
+      addVlExample("specs/scatter_binned.json", "#vis-scatter-binned");
+      addVlExample("specs/bar.json", "#vis-bar");
+      addVlExample("specs/stacked_bar_weather.json", "#vis-stacked-bar");
+      addVlExample("specs/bar_layered_transparent.json", "#vis-layered-bar");
+      addVlExample("specs/line_color.json", "#vis-color-line");
+      addVlExample("specs/overlay_area_short.json", "#vis-overlay-area");
       addVlExample("specs/bar_format_tooltip.json", "#vis-bar-format-tooltip", {
         formatTooltip: (value, sanitize) => `The value of ${sanitize(value.a)} is ${sanitize(value.b)}`,
       });

--- a/examples/vega-lite-examples.html
+++ b/examples/vega-lite-examples.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
   <head>
     <title>Tooltip Examples</title>

--- a/examples/vega-lite-examples.html
+++ b/examples/vega-lite-examples.html
@@ -20,7 +20,7 @@
     <div class="options">
       <div>
         <span>anchor:</span>
-        <label> <input type="radio" name="anchor" value="light" id="anchor-cursor" checked /> cursor </label>
+        <label> <input type="radio" name="anchor" value="cursor" id="anchor-cursor" checked /> cursor </label>
         <label> <input type="radio" name="anchor" value="mark" id="anchor-mark" /> mark </label>
       </div>
     </div>

--- a/examples/vega-lite-examples.html
+++ b/examples/vega-lite-examples.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <title>Tooltip Examples</title>
@@ -50,18 +50,18 @@
         });
       }
 
-      addVlExample("specs/histogram.json", "#vis-histogram");
-      addVlExample("specs/scatter.json", "#vis-scatter");
-      addVlExample("specs/bubble_multiple_aggregation.json", "#vis-bubble-multi-aggr");
-      addVlExample("specs/trellis_barley.json", "#vis-trellis-barley");
-      addVlExample("specs/scatter_binned.json", "#vis-scatter-binned");
-      addVlExample("specs/bar.json", "#vis-bar");
-      addVlExample("specs/stacked_bar_weather.json", "#vis-stacked-bar");
-      addVlExample("specs/bar_layered_transparent.json", "#vis-layered-bar");
-      addVlExample("specs/line_color.json", "#vis-color-line");
-      addVlExample("specs/overlay_area_short.json", "#vis-overlay-area");
+      addVlExample("specs/histogram.json", "#vis-histogram", { anchor: "item" });
+      addVlExample("specs/scatter.json", "#vis-scatter", { anchor: "item" });
+      addVlExample("specs/bubble_multiple_aggregation.json", "#vis-bubble-multi-aggr", { anchor: "item" });
+      addVlExample("specs/trellis_barley.json", "#vis-trellis-barley", { anchor: "item" });
+      addVlExample("specs/scatter_binned.json", "#vis-scatter-binned", { anchor: "item" });
+      addVlExample("specs/bar.json", "#vis-bar", { anchor: "item" });
+      addVlExample("specs/stacked_bar_weather.json", "#vis-stacked-bar", { anchor: "item" });
+      addVlExample("specs/bar_layered_transparent.json", "#vis-layered-bar", { anchor: "item" });
+      addVlExample("specs/line_color.json", "#vis-color-line", { anchor: "item" });
+      addVlExample("specs/overlay_area_short.json", "#vis-overlay-area", { anchor: "item" });
       addVlExample("specs/bar_format_tooltip.json", "#vis-bar-format-tooltip", {
-        formatTooltip: (value, sanitize) => `The value of ${sanitize(value.a)} is ${sanitize(value.b)}`
+        formatTooltip: (value, sanitize) => `The value of ${sanitize(value.a)} is ${sanitize(value.b)}`,
       });
     </script>
   </body>

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "start": "yarn build && concurrently --kill-others -n Server,Rollup 'yarn serve' 'rollup -c -w'",
     "pretest": "yarn build:style",
     "test": "jest",
+    "watch": "jest --watch",
     "test:inspect": "node --inspect-brk ./node_modules/.bin/jest --runInBand",
     "prepare": "yarn copy:data",
     "prettierbase": "prettier '*.{css,scss,html}'",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "start": "yarn build && concurrently --kill-others -n Server,Rollup 'yarn serve' 'rollup -c -w'",
     "pretest": "yarn build:style",
     "test": "jest",
-    "watch": "jest --watch",
     "test:inspect": "node --inspect-brk ./node_modules/.bin/jest --runInBand",
     "prepare": "yarn copy:data",
     "prettierbase": "prettier '*.{css,scss,html}'",

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -1,7 +1,7 @@
 import {TooltipHandler} from 'vega-typings';
 
 import {createDefaultStyle, DEFAULT_OPTIONS, Options} from './defaults';
-import {calculatePositionRelativeToCursor, calculatePositionRelativeToItem} from './position';
+import {calculatePositionRelativeToCursor, calculatePositionRelativeToMark} from './position';
 
 /**
  * The tooltip handler class.
@@ -84,15 +84,8 @@ export class Handler {
 
     let position: {x: number; y: number};
 
-    if (this.options.anchor === 'item') {
-      position = calculatePositionRelativeToItem(
-        event,
-        handler._el.getBoundingClientRect(),
-        handler._origin,
-        item,
-        this.el.getBoundingClientRect(),
-        this.options.position,
-      );
+    if (this.options.anchor === 'mark') {
+      position = calculatePositionRelativeToMark(handler, event, item, this.el.getBoundingClientRect(), this.options);
     } else {
       position = calculatePositionRelativeToCursor(
         event,

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -1,7 +1,7 @@
 import {TooltipHandler} from 'vega-typings';
 
 import {createDefaultStyle, DEFAULT_OPTIONS, Options} from './defaults';
-import {calculatePosition} from './position';
+import {calculatePositionRelativeToCursor, calculatePositionRelativeToItem} from './position';
 
 /**
  * The tooltip handler class.
@@ -54,8 +54,6 @@ export class Handler {
    * The tooltip handler function.
    */
   private tooltipHandler(handler: any, event: MouseEvent, item: any, value: any) {
-    // console.log(handler, event, item, value);
-
     // append a div element that we use as a tooltip unless it already exists
     this.el = document.getElementById(this.options.id);
     if (!this.el) {
@@ -84,14 +82,27 @@ export class Handler {
     // make the tooltip visible
     this.el.classList.add('visible', `${this.options.theme}-theme`);
 
-    const {x, y} = calculatePosition(
-      event,
-      this.el.getBoundingClientRect(),
-      this.options.offsetX,
-      this.options.offsetY,
-    );
+    let position: {x: number; y: number};
 
-    this.el.style.top = `${y}px`;
-    this.el.style.left = `${x}px`;
+    if (this.options.anchor === 'item') {
+      position = calculatePositionRelativeToItem(
+        event,
+        handler._el.getBoundingClientRect(),
+        handler._origin,
+        item,
+        this.el.getBoundingClientRect(),
+        this.options.position,
+      );
+    } else {
+      position = calculatePositionRelativeToCursor(
+        event,
+        this.el.getBoundingClientRect(),
+        this.options.offsetX,
+        this.options.offsetY,
+      );
+    }
+
+    this.el.style.top = `${position.y}px`;
+    this.el.style.left = `${position.x}px`;
   }
 }

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -82,12 +82,12 @@ export class Handler {
     // make the tooltip visible
     this.el.classList.add('visible', `${this.options.theme}-theme`);
 
-    const position =
+    const {x, y} =
       this.options.anchor === 'mark'
         ? calculatePositionRelativeToMark(handler, event, item, this.el.getBoundingClientRect(), this.options)
         : calculatePositionRelativeToCursor(event, this.el.getBoundingClientRect(), this.options);
 
-    this.el.style.top = `${position.y}px`;
-    this.el.style.left = `${position.x}px`;
+    this.el.style.top = `${y}px`;
+    this.el.style.left = `${x}px`;
   }
 }

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -82,18 +82,10 @@ export class Handler {
     // make the tooltip visible
     this.el.classList.add('visible', `${this.options.theme}-theme`);
 
-    let position: {x: number; y: number};
-
-    if (this.options.anchor === 'mark') {
-      position = calculatePositionRelativeToMark(handler, event, item, this.el.getBoundingClientRect(), this.options);
-    } else {
-      position = calculatePositionRelativeToCursor(
-        event,
-        this.el.getBoundingClientRect(),
-        this.options.offsetX,
-        this.options.offsetY,
-      );
-    }
+    const position =
+      this.options.anchor === 'mark'
+        ? calculatePositionRelativeToMark(handler, event, item, this.el.getBoundingClientRect(), this.options)
+        : calculatePositionRelativeToCursor(event, this.el.getBoundingClientRect(), this.options);
 
     this.el.style.top = `${position.y}px`;
     this.el.style.left = `${position.x}px`;

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -85,12 +85,7 @@ export class Handler {
     const position =
       this.options.anchor === 'mark'
         ? calculatePositionRelativeToMark(handler, event, item, this.el.getBoundingClientRect(), this.options)
-        : calculatePositionRelativeToCursor(
-            event,
-            this.el.getBoundingClientRect(),
-            this.options.offsetX,
-            this.options.offsetY,
-          );
+        : calculatePositionRelativeToCursor(event, this.el.getBoundingClientRect(), this.options);
 
     this.el.style.top = `${position.y}px`;
     this.el.style.left = `${position.x}px`;

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -85,7 +85,12 @@ export class Handler {
     const position =
       this.options.anchor === 'mark'
         ? calculatePositionRelativeToMark(handler, event, item, this.el.getBoundingClientRect(), this.options)
-        : calculatePositionRelativeToCursor(event, this.el.getBoundingClientRect(), this.options);
+        : calculatePositionRelativeToCursor(
+            event,
+            this.el.getBoundingClientRect(),
+            this.options.offsetX,
+            this.options.offsetY,
+          );
 
     this.el.style.top = `${position.y}px`;
     this.el.style.left = `${position.x}px`;

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -17,13 +17,6 @@ export interface Options {
   offsetY?: number;
 
   /**
-   * Set the offset of the tooltip in the direction that it is being anchored.
-   *
-   * Example: bottom left would offset the tooltip to the bottom left by the offset value in pixels.
-   */
-  // offset?: number;
-
-  /**
    * ID of the tooltip element.
    */
   id?: string;

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -3,50 +3,52 @@ import defaultStyle from './style';
 
 const EL_ID = 'vg-tooltip-element';
 
-export const DEFAULT_OPTIONS = {
+export type Position = 'top' | 'bottom' | 'left' | 'right' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+
+export interface Options {
   /**
    * X offset.
    */
-  offsetX: 10,
+  offsetX?: number;
 
   /**
    * Y offset.
    */
-  offsetY: 10,
+  offsetY?: number;
 
   /**
    * ID of the tooltip element.
    */
-  id: EL_ID,
+  id?: string;
 
   /**
    * ID of the tooltip CSS style.
    */
-  styleId: 'vega-tooltip-style',
+  styleId?: string;
 
   /**
    * The name of the theme. You can use the CSS class called [THEME]-theme to style the tooltips.
    *
    * There are two predefined themes: "light" (default) and "dark".
    */
-  theme: 'light',
+  theme?: string;
 
   /**
    * Do not use the default styles provided by Vega Tooltip. If you enable this option, you need to use your own styles. It is not necessary to disable the default style when using a custom theme.
    */
-  disableDefaultStyle: false,
+  disableDefaultStyle?: boolean;
 
   /**
    * HTML sanitizer function that removes dangerous HTML to prevent XSS.
    *
    * This should be a function from string to string. You may replace it with a formatter such as a markdown formatter.
    */
-  sanitize: escapeHTML,
+  sanitize?: (value: any) => string;
 
   /**
    * The maximum recursion depth when printing objects in the tooltip.
    */
-  maxDepth: 2,
+  maxDepth?: number;
 
   /**
    * A function to customize the rendered HTML of the tooltip.
@@ -55,15 +57,40 @@ export const DEFAULT_OPTIONS = {
    * @param baseURL The `baseURL` from `options.baseURL`
    * @returns {string} The returned string will become the `innerHTML` of the tooltip element
    */
-  formatTooltip: formatValue,
+  formatTooltip?: (value: any, valueToHtml: (value: any) => string, maxDepth: number, baseURL: string) => string;
 
   /**
    * The baseurl to use in image paths.
    */
-  baseURL: '',
-};
+  baseURL?: string;
 
-export type Options = Partial<typeof DEFAULT_OPTIONS>;
+  /**
+   * The snap reference for the tooltip.
+   */
+  anchor?: 'cursor' | 'item';
+
+  /**
+   * The position of the tooltip relative to the anchor.
+   *
+   * Only valid when `anchor` is set to 'item'.
+   */
+  position?: Position | Position[];
+}
+
+export const DEFAULT_OPTIONS: Required<Options> = {
+  offsetX: 10,
+  offsetY: 10,
+  id: EL_ID,
+  styleId: 'vega-tooltip-style',
+  theme: 'light',
+  disableDefaultStyle: false,
+  sanitize: escapeHTML,
+  maxDepth: 2,
+  formatTooltip: formatValue,
+  baseURL: '',
+  anchor: 'cursor',
+  position: 'top',
+};
 
 /**
  * Escape special HTML characters.

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -17,6 +17,13 @@ export interface Options {
   offsetY?: number;
 
   /**
+   * Set the offset of the tooltip in the direction that it is being anchored.
+   *
+   * Example: bottom left would offset the tooltip to the bottom left by the offset value in pixels.
+   */
+  // offset?: number;
+
+  /**
    * ID of the tooltip element.
    */
   id?: string;
@@ -67,12 +74,12 @@ export interface Options {
   /**
    * The snap reference for the tooltip.
    */
-  anchor?: 'cursor' | 'item';
+  anchor?: 'cursor' | 'mark';
 
   /**
    * The position of the tooltip relative to the anchor.
    *
-   * Only valid when `anchor` is set to 'item'.
+   * Only valid when `anchor` is set to 'mark'.
    */
   position?: Position | Position[];
 }
@@ -89,7 +96,7 @@ export const DEFAULT_OPTIONS: Required<Options> = {
   formatTooltip: formatValue,
   baseURL: '',
   anchor: 'cursor',
-  position: 'top',
+  position: ['top', 'bottom', 'left', 'right', 'top-left', 'top-right', 'bottom-left', 'bottom-right'],
 };
 
 /**

--- a/src/position.ts
+++ b/src/position.ts
@@ -17,17 +17,27 @@ export function calculatePositionRelativeToCursor(
   offsetX: number,
   offsetY: number,
 ) {
-  let x = event.clientX + offsetX;
-  if (x + tooltipBox.width > window.innerWidth) {
-    x = +event.clientX - offsetX - tooltipBox.width;
+  // the possible positions for the tooltip
+  const positions = getPositions(
+    {x1: event.clientX, x2: event.clientX, y1: event.clientY, y2: event.clientY},
+    tooltipBox,
+    offsetX,
+    offsetY,
+  );
+
+  // order of positions to try
+  const postionArr: Position[] = ['bottom-right', 'bottom-left', 'top-right', 'top-left'];
+
+  // test positions till a valid one is found
+  for (const p of postionArr) {
+    if (tooltipIsInViewport(positions[p], tooltipBox)) {
+      return positions[p];
+    }
   }
 
-  let y = event.clientY + offsetY;
-  if (y + tooltipBox.height > window.innerHeight) {
-    y = +event.clientY - offsetY - tooltipBox.height;
-  }
-
-  return {x, y};
+  // default to top-left if a valid position is not found
+  // this is legacy behavior
+  return positions['top-left'];
 }
 
 /**

--- a/src/position.ts
+++ b/src/position.ts
@@ -1,3 +1,5 @@
+import {Position} from './defaults';
+
 /**
  * Position the tooltip
  *
@@ -6,7 +8,7 @@
  * @param offsetX Horizontal offset.
  * @param offsetY Vertical offset.
  */
-export function calculatePosition(
+export function calculatePositionRelativeToCursor(
   event: MouseEvent,
   tooltipBox: {width: number; height: number},
   offsetX: number,
@@ -23,4 +25,115 @@ export function calculatePosition(
   }
 
   return {x, y};
+}
+
+export function calculatePositionRelativeToItem(
+  event: MouseEvent,
+  containerBox: {left: number; top: number},
+  origin: [number, number],
+  item: any,
+  tooltipBox: {width: number; height: number},
+  position: Position | Position[],
+  offset: number = 5,
+) {
+  // if this is a voronoi mark, we want to use the bounds of the point that drew the vornoi cell
+  const markBounds = item.isVoronoi ? item.datum.bounds : item.bounds;
+  let left = containerBox.left + origin[0] + markBounds.x1;
+  let top = containerBox.top + origin[1] + markBounds.y1;
+
+  let parentItem = item;
+
+  while (parentItem.mark.group) {
+    parentItem = parentItem.mark.group;
+    if ('x' in parentItem && 'y' in parentItem) {
+      left += parentItem.x;
+      top += parentItem.y;
+    }
+  }
+
+  const width = markBounds.x2 - markBounds.x1;
+  const height = markBounds.y2 - markBounds.y1;
+
+  const anchorBounds = {
+    x1: left,
+    x2: left + width,
+    y1: top,
+    y2: top + height,
+  };
+  const diagnalOffset = offset / Math.sqrt(2);
+  const xc = (anchorBounds.x1 + anchorBounds.x2) / 2;
+  const yc = (anchorBounds.y1 + anchorBounds.y2) / 2;
+
+  const yPositions = {
+    top: anchorBounds.y1 - tooltipBox.height,
+    middle: yc - tooltipBox.height / 2,
+    bottom: anchorBounds.y2,
+  };
+
+  const xPositions = {
+    left: anchorBounds.x1 - tooltipBox.width,
+    center: xc - tooltipBox.width / 2,
+    right: anchorBounds.x2,
+  };
+
+  const positions: Record<Position, {x: number; y: number}> = {
+    top: {x: xPositions.center, y: yPositions.top - offset},
+    bottom: {x: xPositions.center, y: yPositions.bottom + offset},
+    left: {x: xPositions.left - offset, y: yPositions.middle},
+    right: {x: xPositions.right + offset, y: yPositions.middle},
+    'top-left': {x: xPositions.left - diagnalOffset, y: yPositions.top - diagnalOffset},
+    'top-right': {x: xPositions.right + diagnalOffset, y: yPositions.top - diagnalOffset},
+    'bottom-left': {x: xPositions.left - diagnalOffset, y: yPositions.bottom + diagnalOffset},
+    'bottom-right': {x: xPositions.right + diagnalOffset, y: yPositions.bottom + diagnalOffset},
+  };
+
+  // order to attempt positioning the tooltip
+  let positionOrder: Position[] = [
+    'top',
+    'bottom',
+    'left',
+    'right',
+    'top-left',
+    'top-right',
+    'bottom-left',
+    'bottom-right',
+  ];
+
+  if (Array.isArray(position)) {
+    positionOrder = position;
+  } else {
+    positionOrder.unshift(position);
+  }
+
+  for (const p of positionOrder) {
+    // verify that the tooltip is in the view and the mouse is not where the tooltip would be
+    if (isInView(positions[p], tooltipBox) && !mouseIsOnTooltip(event, positions[p], tooltipBox)) {
+      return positions[p];
+    }
+  }
+
+  // default to the first position
+  return positions[positionOrder[0]];
+}
+
+function isInView(position: {x: number; y: number}, tooltipBox: {width: number; height: number}) {
+  return (
+    position.x >= 0 &&
+    position.y >= 0 &&
+    position.x + tooltipBox.width <= window.innerWidth &&
+    position.y + tooltipBox.height <= window.innerHeight
+  );
+}
+
+function mouseIsOnTooltip(
+  event: MouseEvent,
+  position: {x: number; y: number},
+  tooltipBox: {width: number; height: number},
+) {
+  return (
+    event.clientX >= position.x &&
+    event.clientX <= position.x + tooltipBox.width &&
+    event.clientY >= position.y &&
+    event.clientY <= position.y + tooltipBox.height
+  );
 }

--- a/src/position.ts
+++ b/src/position.ts
@@ -70,7 +70,7 @@ export function calculatePositionRelativeToMark(
   return calculatePositionRelativeToCursor(event, tooltipBox, offsetX, offsetY);
 }
 
-// Calculates the bounds of the mark relative to the viewport
+// Calculates the bounds of the mark relative to the viewport.
 export function getMarkBounds(
   containerBox: {left: number; top: number},
   origin: [number, number],
@@ -104,8 +104,7 @@ export function getMarkBounds(
   };
 }
 
-// calculates the tooltip xy for each possible position
-//update to handle offsetX and offsetY
+// Calculates the tooltip xy for each possible position.
 export function getPositions(
   markBounds: MarkBounds,
   tooltipBox: {width: number; height: number},

--- a/src/position.ts
+++ b/src/position.ts
@@ -147,7 +147,7 @@ export function getPositions(
 }
 
 // Checks if the tooltip would be in the viewport at the given position
-function tooltipIsInViewport(position: {x: number; y: number}, tooltipBox: {width: number; height: number}) {
+export function tooltipIsInViewport(position: {x: number; y: number}, tooltipBox: {width: number; height: number}) {
   return (
     position.x >= 0 &&
     position.y >= 0 &&
@@ -157,7 +157,7 @@ function tooltipIsInViewport(position: {x: number; y: number}, tooltipBox: {widt
 }
 
 // Checks if the mouse is within the tooltip area
-function mouseIsOnTooltip(
+export function mouseIsOnTooltip(
   event: MouseEvent,
   position: {x: number; y: number},
   tooltipBox: {width: number; height: number},

--- a/src/position.ts
+++ b/src/position.ts
@@ -8,14 +8,12 @@ type MarkBounds = Pick<Bounds, 'x1' | 'x2' | 'y1' | 'y2'>;
  *
  * @param event The mouse event.
  * @param tooltipBox
- * @param offsetX Horizontal offset.
- * @param offsetY Vertical offset.
+ * @param options Tooltip handler options.
  */
 export function calculatePositionRelativeToCursor(
   event: MouseEvent,
   tooltipBox: {width: number; height: number},
-  offsetX: number,
-  offsetY: number,
+  {offsetX, offsetY}: Required<Options>,
 ) {
   // the possible positions for the tooltip
   const positions = getPositions(
@@ -54,8 +52,9 @@ export function calculatePositionRelativeToMark(
   event: MouseEvent,
   item: any,
   tooltipBox: {width: number; height: number},
-  {position, offsetX, offsetY}: Required<Options>,
+  options: Required<Options>,
 ) {
+  const {position, offsetX, offsetY} = options;
   const containerBox = handler._el.getBoundingClientRect();
   const origin = handler._origin;
 
@@ -77,7 +76,7 @@ export function calculatePositionRelativeToMark(
   }
 
   // default to cursor position if a valid position is not found
-  return calculatePositionRelativeToCursor(event, tooltipBox, offsetX, offsetY);
+  return calculatePositionRelativeToCursor(event, tooltipBox, options);
 }
 
 // Calculates the bounds of the mark relative to the viewport.

--- a/src/position.ts
+++ b/src/position.ts
@@ -1,4 +1,7 @@
-import {Position} from './defaults';
+import {Bounds} from 'vega-typings';
+import {Options, Position} from './defaults';
+
+type MarkBounds = Pick<Bounds, 'x1' | 'x2' | 'y1' | 'y2'>;
 
 /**
  * Position the tooltip
@@ -27,22 +30,60 @@ export function calculatePositionRelativeToCursor(
   return {x, y};
 }
 
-export function calculatePositionRelativeToItem(
+/**
+ * calculates the position of the tooltip relative to the mark
+ * @param event The mouse event.
+ * @param containerBox The bounding box of the container relative to the viewport.
+ * @param origin The origin of the chart area.
+ * @param item The item that the tooltip is being shown for.
+ * @param tooltipBox The bounding box of the tooltip.
+ * @param position The position of the tooltip relative to the mark.
+ * @param offset The offset from the mark.
+ * @returns
+ */
+export function calculatePositionRelativeToMark(
+  handler: any,
   event: MouseEvent,
-  containerBox: {left: number; top: number},
-  origin: [number, number],
   item: any,
   tooltipBox: {width: number; height: number},
-  position: Position | Position[],
-  offset: number = 5,
+  {position, offsetX, offsetY}: Required<Options>,
 ) {
-  // if this is a voronoi mark, we want to use the bounds of the point that drew the vornoi cell
+  const containerBox = handler._el.getBoundingClientRect();
+  const origin = handler._origin;
+
+  // bounds of the mark relative to the viewport
+  const markBounds = getMarkBounds(containerBox, origin, item);
+
+  // the possible positions for the tooltip
+  // TODO: use offset from options
+  const positions = getPositions(markBounds, tooltipBox, 20);
+
+  // positions to test
+  const positionArr = Array.isArray(position) ? position : [position];
+
+  // test positions till a valid one is found
+  for (const p of positionArr) {
+    // verify that the tooltip is in the view and the mouse is not where the tooltip would be
+    if (isInView(positions[p], tooltipBox) && !mouseIsOnTooltip(event, positions[p], tooltipBox)) {
+      return positions[p];
+    }
+  }
+
+  // default to cursor position if a valid position is not found
+  return calculatePositionRelativeToCursor(event, tooltipBox, offsetX, offsetY);
+}
+
+// Calculates the bounds of the mark relative to the viewport
+function getMarkBounds(containerBox: {left: number; top: number}, origin: [number, number], item: any): MarkBounds {
+  // if this is a voronoi mark, we want to use the bounds of the point that voronoi cell represents
   const markBounds = item.isVoronoi ? item.datum.bounds : item.bounds;
+
   let left = containerBox.left + origin[0] + markBounds.x1;
   let top = containerBox.top + origin[1] + markBounds.y1;
 
+  // traverse mark groups, summing their offsets to get the total offset
+  // item bounds are relative to their group so if there are multiple nested groups we need to add them all
   let parentItem = item;
-
   while (parentItem.mark.group) {
     parentItem = parentItem.mark.group;
     if ('x' in parentItem && 'y' in parentItem) {
@@ -51,15 +92,19 @@ export function calculatePositionRelativeToItem(
     }
   }
 
-  const width = markBounds.x2 - markBounds.x1;
-  const height = markBounds.y2 - markBounds.y1;
+  const markWidth = markBounds.x2 - markBounds.x1;
+  const markHeight = markBounds.y2 - markBounds.y1;
 
-  const anchorBounds = {
+  return {
     x1: left,
-    x2: left + width,
+    x2: left + markWidth,
     y1: top,
-    y2: top + height,
+    y2: top + markHeight,
   };
+}
+
+// calculates the tooltip xy for each possible position
+function getPositions(anchorBounds: MarkBounds, tooltipBox: {width: number; height: number}, offset: number) {
   const diagnalOffset = offset / Math.sqrt(2);
   const xc = (anchorBounds.x1 + anchorBounds.x2) / 2;
   const yc = (anchorBounds.y1 + anchorBounds.y2) / 2;
@@ -86,36 +131,10 @@ export function calculatePositionRelativeToItem(
     'bottom-left': {x: xPositions.left - diagnalOffset, y: yPositions.bottom + diagnalOffset},
     'bottom-right': {x: xPositions.right + diagnalOffset, y: yPositions.bottom + diagnalOffset},
   };
-
-  // order to attempt positioning the tooltip
-  let positionOrder: Position[] = [
-    'top',
-    'bottom',
-    'left',
-    'right',
-    'top-left',
-    'top-right',
-    'bottom-left',
-    'bottom-right',
-  ];
-
-  if (Array.isArray(position)) {
-    positionOrder = position;
-  } else {
-    positionOrder.unshift(position);
-  }
-
-  for (const p of positionOrder) {
-    // verify that the tooltip is in the view and the mouse is not where the tooltip would be
-    if (isInView(positions[p], tooltipBox) && !mouseIsOnTooltip(event, positions[p], tooltipBox)) {
-      return positions[p];
-    }
-  }
-
-  // default to the first position
-  return positions[positionOrder[0]];
+  return positions;
 }
 
+// Checks if the tooltip would be in view at the given position
 function isInView(position: {x: number; y: number}, tooltipBox: {width: number; height: number}) {
   return (
     position.x >= 0 &&
@@ -125,6 +144,7 @@ function isInView(position: {x: number; y: number}, tooltipBox: {width: number; 
   );
 }
 
+// Checks if the mouse is within the tooltip area
 function mouseIsOnTooltip(
   event: MouseEvent,
   position: {x: number; y: number},

--- a/test/position.test.ts
+++ b/test/position.test.ts
@@ -12,8 +12,6 @@ Object.defineProperty(window, 'innerHeight', {value: 500});
 
 const defaultTooltipBox = {width: 100, height: 100};
 const defaultMouseEvent = {clientX: 100, clientY: 100} as MouseEvent;
-const defaultOffsetX = 10;
-const defaultOffsetY = 10;
 
 const defaultItem = {
   isVoronoi: false,
@@ -23,20 +21,14 @@ const defaultItem = {
 
 describe('calculatePositionRelativeToCursor()', () => {
   test('should return position in bottom right corner of cursor if there is enough space', () => {
-    const position = calculatePositionRelativeToCursor(
-      defaultMouseEvent,
-      defaultTooltipBox,
-      defaultOffsetX,
-      defaultOffsetY,
-    );
+    const position = calculatePositionRelativeToCursor(defaultMouseEvent, defaultTooltipBox, DEFAULT_OPTIONS);
     expect(position).toEqual({x: 110, y: 110});
   });
   test('should return position in top right corner of cursor if there is not space below', () => {
     const position = calculatePositionRelativeToCursor(
       {...defaultMouseEvent, clientY: 480},
       defaultTooltipBox,
-      defaultOffsetX,
-      defaultOffsetY,
+      DEFAULT_OPTIONS,
     );
     expect(position).toEqual({x: 110, y: 370});
   });
@@ -44,8 +36,7 @@ describe('calculatePositionRelativeToCursor()', () => {
     const position = calculatePositionRelativeToCursor(
       {...defaultMouseEvent, clientX: 480},
       defaultTooltipBox,
-      defaultOffsetX,
-      defaultOffsetY,
+      DEFAULT_OPTIONS,
     );
     expect(position).toEqual({x: 370, y: 110});
   });
@@ -53,8 +44,7 @@ describe('calculatePositionRelativeToCursor()', () => {
     const position = calculatePositionRelativeToCursor(
       {...defaultMouseEvent, clientX: 480, clientY: 480},
       defaultTooltipBox,
-      defaultOffsetX,
-      defaultOffsetY,
+      DEFAULT_OPTIONS,
     );
     expect(position).toEqual({x: 370, y: 370});
   });

--- a/test/position.test.ts
+++ b/test/position.test.ts
@@ -1,4 +1,10 @@
-import {calculatePositionRelativeToCursor} from '../src';
+import {
+  calculatePositionRelativeToCursor,
+  calculatePositionRelativeToMark,
+  DEFAULT_OPTIONS,
+  getMarkBounds,
+  getPositions,
+} from '../src';
 
 global.window = Object.create({});
 Object.defineProperty(window, 'innerWidth', {value: 500});
@@ -8,6 +14,12 @@ const defaultTooltipBox = {width: 100, height: 100};
 const defaultMouseEvent = {clientX: 100, clientY: 100} as MouseEvent;
 const defaultOffsetX = 10;
 const defaultOffsetY = 10;
+
+const defaultItem = {
+  isVoronoi: false,
+  bounds: {x1: 150, x2: 200, y1: 75, y2: 125},
+  mark: {},
+};
 
 describe('calculatePositionRelativeToCursor()', () => {
   test('should return position in bottom right corner of cursor if there is enough space', () => {
@@ -45,5 +57,80 @@ describe('calculatePositionRelativeToCursor()', () => {
       defaultOffsetY,
     );
     expect(position).toEqual({x: 370, y: 370});
+  });
+});
+
+describe('calculatePositionRelativeToMark()', () => {
+  const handler = {_el: {getBoundingClientRect: () => ({left: 100, top: 100})}, _origin: [0, 0]};
+  test('should return position on top if there is enough space', () => {
+    const position = calculatePositionRelativeToMark(
+      handler,
+      defaultMouseEvent,
+      defaultItem,
+      defaultTooltipBox,
+      DEFAULT_OPTIONS,
+    );
+    expect(position).toEqual({x: 225, y: 65});
+  });
+  test('should use mouse position if there is not room in the viewport for available options', () => {
+    const position = calculatePositionRelativeToMark(
+      handler,
+      defaultMouseEvent,
+      {...defaultItem, bounds: {x1: 0, x2: 400, y1: 0, y2: 400}},
+      {width: 200, height: 200},
+      DEFAULT_OPTIONS,
+    );
+    expect(position).toEqual({x: 110, y: 110});
+  });
+});
+
+describe('getMarkBounds()', () => {
+  test('should return the bounds of the mark', () => {
+    expect(getMarkBounds({left: 100, top: 100}, [0, 0], defaultItem)).toEqual({x1: 250, x2: 300, y1: 175, y2: 225});
+    expect(getMarkBounds({left: 150, top: 100}, [0, 0], defaultItem)).toEqual({x1: 300, x2: 350, y1: 175, y2: 225});
+    expect(getMarkBounds({left: 100, top: 150}, [0, 0], defaultItem)).toEqual({x1: 250, x2: 300, y1: 225, y2: 275});
+    expect(getMarkBounds({left: 100, top: 100}, [10, 0], defaultItem)).toEqual({x1: 260, x2: 310, y1: 175, y2: 225});
+    expect(getMarkBounds({left: 100, top: 100}, [0, 10], defaultItem)).toEqual({x1: 250, x2: 300, y1: 185, y2: 235});
+  });
+  test('should use the bounds of the voronoi mark if it is a voronoi mark', () => {
+    const item = {
+      ...defaultItem,
+      datum: {bounds: {x1: 35, x2: 45, y1: 55, y2: 65}},
+    };
+    expect(getMarkBounds({left: 100, top: 100}, [0, 0], {...item, isVoronoi: true})).toEqual({
+      x1: 135,
+      x2: 145,
+      y1: 155,
+      y2: 165,
+    });
+    expect(getMarkBounds({left: 100, top: 100}, [0, 0], {...item, isVoronoi: false})).toEqual({
+      x1: 250,
+      x2: 300,
+      y1: 175,
+      y2: 225,
+    });
+  });
+  test('should sum the offsets of parent groups', () => {
+    const item = {...defaultItem, mark: {group: {x: 10, y: 20, mark: {group: {x: 30, y: 40, mark: {}}}}}};
+    expect(getMarkBounds({left: 0, top: 0}, [0, 0], defaultItem)).toEqual({x1: 150, x2: 200, y1: 75, y2: 125});
+    expect(getMarkBounds({left: 0, top: 0}, [0, 0], item)).toEqual({x1: 190, x2: 240, y1: 135, y2: 185});
+  });
+});
+
+describe('getPositions()', () => {
+  test('should calculate all the possible positions for the tooltip', () => {
+    const markBounds = {x1: 0, x2: 50, y1: 0, y2: 50};
+    const tooltipBox = {width: 200, height: 100};
+
+    const positions = getPositions(markBounds, tooltipBox, 10, 10);
+
+    expect(positions).toHaveProperty('top', {x: -75, y: -110});
+    expect(positions).toHaveProperty('bottom', {x: -75, y: 60});
+    expect(positions).toHaveProperty('left', {x: -210, y: -25});
+    expect(positions).toHaveProperty('right', {x: 60, y: -25});
+    expect(positions).toHaveProperty('top-left', {x: -210, y: -110});
+    expect(positions).toHaveProperty('top-right', {x: 60, y: -110});
+    expect(positions).toHaveProperty('bottom-left', {x: -210, y: 60});
+    expect(positions).toHaveProperty('bottom-right', {x: 60, y: 60});
   });
 });

--- a/test/position.test.ts
+++ b/test/position.test.ts
@@ -1,0 +1,49 @@
+import {calculatePositionRelativeToCursor} from '../src';
+
+global.window = Object.create({});
+Object.defineProperty(window, 'innerWidth', {value: 500});
+Object.defineProperty(window, 'innerHeight', {value: 500});
+
+const defaultTooltipBox = {width: 100, height: 100};
+const defaultMouseEvent = {clientX: 100, clientY: 100} as MouseEvent;
+const defaultOffsetX = 10;
+const defaultOffsetY = 10;
+
+describe('calculatePositionRelativeToCursor()', () => {
+  test('should return position in bottom right corner of cursor if there is enough space', () => {
+    const position = calculatePositionRelativeToCursor(
+      defaultMouseEvent,
+      defaultTooltipBox,
+      defaultOffsetX,
+      defaultOffsetY,
+    );
+    expect(position).toEqual({x: 110, y: 110});
+  });
+  test('should return position in top right corner of cursor if there is not space below', () => {
+    const position = calculatePositionRelativeToCursor(
+      {...defaultMouseEvent, clientY: 480},
+      defaultTooltipBox,
+      defaultOffsetX,
+      defaultOffsetY,
+    );
+    expect(position).toEqual({x: 110, y: 370});
+  });
+  test('should return position in bottom left corner of cursor if there is not space to the right', () => {
+    const position = calculatePositionRelativeToCursor(
+      {...defaultMouseEvent, clientX: 480},
+      defaultTooltipBox,
+      defaultOffsetX,
+      defaultOffsetY,
+    );
+    expect(position).toEqual({x: 370, y: 110});
+  });
+  test('should return position in top left corner of cursor if there is not space below and to the right', () => {
+    const position = calculatePositionRelativeToCursor(
+      {...defaultMouseEvent, clientX: 480, clientY: 480},
+      defaultTooltipBox,
+      defaultOffsetX,
+      defaultOffsetY,
+    );
+    expect(position).toEqual({x: 370, y: 370});
+  });
+});

--- a/test/position.test.ts
+++ b/test/position.test.ts
@@ -4,6 +4,8 @@ import {
   DEFAULT_OPTIONS,
   getMarkBounds,
   getPositions,
+  mouseIsOnTooltip,
+  tooltipIsInViewport,
 } from '../src';
 
 global.window = Object.create({});
@@ -122,5 +124,38 @@ describe('getPositions()', () => {
     expect(positions).toHaveProperty('top-right', {x: 60, y: -110});
     expect(positions).toHaveProperty('bottom-left', {x: -210, y: 60});
     expect(positions).toHaveProperty('bottom-right', {x: 60, y: 60});
+  });
+});
+
+describe('tooltipIsInViewport()', () => {
+  const tooltipBox = {width: 100, height: 100};
+  test('should return true if the tooltip is in the viewport', () => {
+    expect(tooltipIsInViewport({x: 0, y: 0}, tooltipBox)).toBe(true);
+    expect(tooltipIsInViewport({x: 400, y: 400}, tooltipBox)).toBe(true);
+    expect(tooltipIsInViewport({x: 0, y: 400}, tooltipBox)).toBe(true);
+    expect(tooltipIsInViewport({x: 400, y: 0}, tooltipBox)).toBe(true);
+  });
+  test('should return false if the tooltip is not in the viewport', () => {
+    expect(tooltipIsInViewport({x: -1, y: 0}, tooltipBox)).toBe(false);
+    expect(tooltipIsInViewport({x: 0, y: -1}, tooltipBox)).toBe(false);
+    expect(tooltipIsInViewport({x: 401, y: 0}, tooltipBox)).toBe(false);
+    expect(tooltipIsInViewport({x: 0, y: 401}, tooltipBox)).toBe(false);
+  });
+});
+
+describe('mouseIsOnTooltip()', () => {
+  const tooltipBox = {width: 100, height: 100};
+  test('should return true if the mouse is on the tooltip', () => {
+    expect(mouseIsOnTooltip(defaultMouseEvent, {x: 0, y: 0}, tooltipBox)).toBe(true);
+    expect(mouseIsOnTooltip(defaultMouseEvent, {x: 50, y: 50}, tooltipBox)).toBe(true);
+    expect(mouseIsOnTooltip(defaultMouseEvent, {x: 100, y: 100}, tooltipBox)).toBe(true);
+    expect(mouseIsOnTooltip(defaultMouseEvent, {x: 100, y: 0}, tooltipBox)).toBe(true);
+    expect(mouseIsOnTooltip(defaultMouseEvent, {x: 0, y: 100}, tooltipBox)).toBe(true);
+  });
+  test('should return false if the mouse is not on the tooltip', () => {
+    expect(mouseIsOnTooltip(defaultMouseEvent, {x: -1, y: 0}, tooltipBox)).toBe(false);
+    expect(mouseIsOnTooltip(defaultMouseEvent, {x: 0, y: -1}, tooltipBox)).toBe(false);
+    expect(mouseIsOnTooltip(defaultMouseEvent, {x: 101, y: 0}, tooltipBox)).toBe(false);
+    expect(mouseIsOnTooltip(defaultMouseEvent, {x: 0, y: 101}, tooltipBox)).toBe(false);
   });
 });


### PR DESCRIPTION
Add options and support for snapping tooltips to the associated mark and set the position.

# Issue

fixes #200 

# API
```
Options {
...
anchor: 'cursor' | 'mark';
position: Postion | Position[];
}

type Position = 'top' | 'bottom' | 'left' | 'right' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
```
Each of the position options match the available `anchor` options on the [vega label transform](https://vega.github.io/vega/docs/transforms/label/).

# Behavior
Setting the `anchor = 'mark'` will make it so that the tooltip snaps to the associated mark. For `voronoi` paths, it will use the point that the voronoi path is derived from.

The tooltip will be positioned based on the `position` option. If only one position is provided, it will attempt to place the tooltip in that location. If the tooltip would be partially out of the viewport at this position or if the cursor location would overlap the tooltip, then it defaults back to snapping to the cursor position.

If multiple positions are supplied in the `position` option, then the algo will try to place the tooltip in each position until it finds one that is in the viewport and does not overlap the cursor location. If none of the positions meet this criteria, it will default back to anchoring to the cursor position.

The `offsetX` and `offsetY` options are honored. If a tooltip is placed directly to the left or right, only the `offsetX` is applied. If the tooltip is placed directly above or below the mark, only the `offsetY` is applied. If placed on one of the corners, both offsets are applied, just like with the cursor position calculation.

## Positioning Example

https://github.com/user-attachments/assets/f62b348d-d7fa-4bb4-9c56-d75c490d33c3



