### PR TITLE
fix: mark position calculation when only x or y are defined

### DIFF
--- a/src/position.ts
+++ b/src/position.ts
@@ -96,12 +96,8 @@ export function getMarkBounds(
   let parentItem = item;
   while (parentItem.mark.group) {
     parentItem = parentItem.mark.group;
-    if ('x' in parentItem) {
-      left += parentItem.x;
-    }
-    if ('y' in parentItem) {
-      top += parentItem.y;
-    }
+    left += parentItem.x ?? 0;
+    top += parentItem.y ?? 0;
   }
 
   const markWidth = markBounds.x2 - markBounds.x1;

--- a/src/position.ts
+++ b/src/position.ts
@@ -96,8 +96,10 @@ export function getMarkBounds(
   let parentItem = item;
   while (parentItem.mark.group) {
     parentItem = parentItem.mark.group;
-    if ('x' in parentItem && 'y' in parentItem) {
+    if ('x' in parentItem) {
       left += parentItem.x;
+    }
+    if ('y' in parentItem) {
       top += parentItem.y;
     }
   }

--- a/test/position.test.ts
+++ b/test/position.test.ts
@@ -107,6 +107,10 @@ describe('getMarkBounds()', () => {
     expect(getMarkBounds({left: 0, top: 0}, [0, 0], defaultItem)).toEqual({x1: 150, x2: 200, y1: 75, y2: 125});
     expect(getMarkBounds({left: 0, top: 0}, [0, 0], item)).toEqual({x1: 190, x2: 240, y1: 135, y2: 185});
   });
+  test('should sum the offsets even if only x is defined', () => {
+    const item = {...defaultItem, mark: {group: {x: 10, mark: {group: {x: 30, mark: {}}}}}};
+    expect(getMarkBounds({left: 0, top: 0}, [0, 0], item)).toEqual({x1: 190, x2: 240, y1: 75, y2: 125});
+  });
 });
 
 describe('getPositions()', () => {


### PR DESCRIPTION
# Mark Position Bug Fix

It's possible for only `x` or `y` to be defined on a group item. The logic in place checked if both were defined and then summed their offsets. This fix checks them independently so that if only one or the other is defined, they are still summed up.

## Verification

Validated against `@adobe/react-spectrum-charts` that this change fixes the bug I was seeing there.

A test has been added to verify and catch this.