### PR TITLE
feat: Support newlines

### DIFF
--- a/vega-tooltip.scss
+++ b/vega-tooltip.scss
@@ -7,6 +7,7 @@
   font-size: 11px;
   border-radius: 3px;
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
+  white-space: pre-line;
 
   &.visible {
     visibility: visible;
@@ -34,6 +35,7 @@
           max-width: 150px;
           text-align: right;
           padding-right: 4px;
+          vertical-align: text-top;
         }
         &.value {
           display: block;


### PR DESCRIPTION
This PR enables support for rendering newlines in tooltips by adding `white-space: pre-line` to the`#vg-tooltip-element` style. It also aligns text in the key cells to the top.

This change complements a [corresponding PR](https://github.com/vega/vega-lite/pull/9647) in the vega-lite repository.

